### PR TITLE
fix: cargo fmt --all (CI rustfmt)

### DIFF
--- a/crates/cs-core/src/db.rs
+++ b/crates/cs-core/src/db.rs
@@ -302,9 +302,9 @@ impl Database {
     }
 
     pub fn load_lsp_edges(&self) -> Result<Vec<crate::symbol::LspEdge>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT from_fqn, to_fqn, kind, resolved_type FROM lsp_edges",
-        )?;
+        let mut stmt = self
+            .conn
+            .prepare("SELECT from_fqn, to_fqn, kind, resolved_type FROM lsp_edges")?;
         let rows = stmt.query_map([], |r| {
             Ok(crate::symbol::LspEdge {
                 from_fqn: r.get(0)?,
@@ -313,13 +313,15 @@ impl Database {
                 resolved_type: r.get(3)?,
             })
         })?;
-        rows.collect::<rusqlite::Result<Vec<_>>>().map_err(Into::into)
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
     }
 
     pub fn lsp_edge_count(&self) -> Result<u64> {
         Ok(self
             .conn
-            .query_row("SELECT COUNT(*) FROM lsp_edges", [], |r| r.get::<_, i64>(0))? as u64)
+            .query_row("SELECT COUNT(*) FROM lsp_edges", [], |r| r.get::<_, i64>(0))?
+            as u64)
     }
 
     // ── Files ─────────────────────────────────────────────────────────────────
@@ -594,8 +596,10 @@ impl Database {
         );
 
         let mut stmt = self.conn.prepare(&sql)?;
-        let params_vec: Vec<&dyn rusqlite::types::ToSql> =
-            terms.iter().map(|t| t as &dyn rusqlite::types::ToSql).collect();
+        let params_vec: Vec<&dyn rusqlite::types::ToSql> = terms
+            .iter()
+            .map(|t| t as &dyn rusqlite::types::ToSql)
+            .collect();
         let results = stmt
             .query_map(params_vec.as_slice(), |row| {
                 // row_to_observation reads columns 0..9; column 10 is _score (ignored)

--- a/crates/cs-core/src/memory.rs
+++ b/crates/cs-core/src/memory.rs
@@ -599,7 +599,10 @@ mod obs_kind_tests {
     #[test]
     fn consolidated_expires_at_is_set_on_new() {
         let obs = Observation::new("s", "content", None, None, ObservationKind::Consolidated);
-        assert!(obs.expires_at.is_some(), "Consolidated must have an expires_at");
+        assert!(
+            obs.expires_at.is_some(),
+            "Consolidated must have an expires_at"
+        );
     }
 
     /// expires_at() on MemoryConfig should assign a non-None TTL for Consolidated.

--- a/crates/cs-core/src/pyright_enrich.rs
+++ b/crates/cs-core/src/pyright_enrich.rs
@@ -53,10 +53,7 @@ pub fn run_pyright_enrichment(
     db: &Database,
 ) -> usize {
     // Gate 1: must have Python symbols to enrich
-    if !all_symbols
-        .iter()
-        .any(|s| s.language == Language::Python)
-    {
+    if !all_symbols.iter().any(|s| s.language == Language::Python) {
         return 0;
     }
 
@@ -137,10 +134,7 @@ fn collect_py_stats(dir: &Path, parts: &mut Vec<String>) {
     for entry in entries.flatten() {
         let path = entry.path();
         if path.is_dir() {
-            let name = path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("");
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
             // Skip hidden dirs and common virtual-env / cache directories
             if name.starts_with('.')
                 || name == "node_modules"
@@ -217,28 +211,19 @@ fn parse_pyright_diagnostics(
         return map;
     };
 
-    let Some(diags) = root
-        .get("generalDiagnostics")
-        .and_then(|v| v.as_array())
-    else {
+    let Some(diags) = root.get("generalDiagnostics").and_then(|v| v.as_array()) else {
         return map;
     };
 
     for diag in diags {
-        let severity = diag
-            .get("severity")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
+        let severity = diag.get("severity").and_then(|v| v.as_str()).unwrap_or("");
         // Only information-level diagnostics carry inferred-type messages
         if severity != "information" {
             continue;
         }
 
         let file = diag.get("file").and_then(|v| v.as_str()).unwrap_or("");
-        let message = diag
-            .get("message")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
+        let message = diag.get("message").and_then(|v| v.as_str()).unwrap_or("");
         // pyright reports 0-based lines; we store 1-based to match Symbol::start_line
         let line = diag
             .pointer("/range/start/line")
@@ -421,9 +406,7 @@ mod tests {
     fn extract_return_type_callable_default() {
         // Signature contains "->" inside a default value; rfind picks the last one
         assert_eq!(
-            extract_return_type_from_sig(
-                "def f(cb: Callable[[], int] = lambda: 0) -> str:"
-            ),
+            extract_return_type_from_sig("def f(cb: Callable[[], int] = lambda: 0) -> str:"),
             Some("str".to_string())
         );
     }
@@ -544,10 +527,7 @@ mod tests {
         let diag_map = HashMap::new();
         let count = merge_pyright_types(std::slice::from_mut(&mut sym), &diag_map);
         assert_eq!(count, 1);
-        assert_eq!(
-            sym.resolved_type.as_deref(),
-            Some("APIView, LogMixin")
-        );
+        assert_eq!(sym.resolved_type.as_deref(), Some("APIView, LogMixin"));
     }
 
     #[test]
@@ -606,7 +586,10 @@ mod tests {
         })
         .to_string();
         let map = parse_pyright_diagnostics(&json, workspace.path());
-        assert!(map.is_empty(), "error/warning diagnostics should be ignored");
+        assert!(
+            map.is_empty(),
+            "error/warning diagnostics should be ignored"
+        );
     }
 
     #[test]
@@ -694,6 +677,9 @@ mod tests {
         // returns 0 without attempting to call pyright.
         let count = run_pyright_enrichment(dir.path(), std::slice::from_mut(&mut sym), &db);
         assert_eq!(count, 0, "cache hit should short-circuit to 0");
-        assert!(sym.resolved_type.is_none(), "symbol must not be mutated on cache hit");
+        assert!(
+            sym.resolved_type.is_none(),
+            "symbol must not be mutated on cache hit"
+        );
     }
 }

--- a/crates/cs-core/tests/engine.rs
+++ b/crates/cs-core/tests/engine.rs
@@ -1023,11 +1023,7 @@ fn indexing_config_reads_python_pyright() {
     use cs_core::memory::IndexingConfig;
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
-    std::fs::write(
-        &config_path,
-        "[indexing]\npython_pyright = true\n",
-    )
-    .unwrap();
+    std::fs::write(&config_path, "[indexing]\npython_pyright = true\n").unwrap();
     let cfg = IndexingConfig::load_from_toml(&config_path);
     assert!(cfg.python_pyright, "python_pyright should be true");
 }
@@ -1084,13 +1080,8 @@ fn search_memory_returns_empty_for_no_match() {
         .save_observation("completely unrelated observation", None)
         .unwrap();
 
-    let results = engine
-        .search_memory("xyzzy frobulate", None)
-        .unwrap();
-    assert!(
-        results.is_empty(),
-        "expected no results for nonsense query"
-    );
+    let results = engine.search_memory("xyzzy frobulate", None).unwrap();
+    assert!(results.is_empty(), "expected no results for nonsense query");
 }
 
 /// `search_memory` ranks observations with more matching terms higher.
@@ -1100,9 +1091,7 @@ fn search_memory_ranks_by_term_overlap() {
     let engine = test_engine(&dir);
 
     // One term match
-    engine
-        .save_observation("retry logic exists", None)
-        .unwrap();
+    engine.save_observation("retry logic exists", None).unwrap();
     // Two term match — should rank higher
     engine
         .save_observation("retry backoff is implemented", None)
@@ -1185,7 +1174,10 @@ fn get_symbol_snippet_returns_body_for_known_fqn() {
     // If found, signature must be non-empty
     if let Some((sig, _body)) = snippet {
         assert!(!sig.is_empty(), "signature should be non-empty");
-        assert!(sig.contains("add"), "signature should mention function name");
+        assert!(
+            sig.contains("add"),
+            "signature should mention function name"
+        );
     }
     // Getting a snippet for an unknown FQN returns None
     assert!(
@@ -1261,7 +1253,10 @@ fn submit_lsp_edges_idempotent() {
     engine.submit_lsp_edges(&edge).unwrap();
 
     let stats = engine.index_stats().unwrap();
-    assert_eq!(stats.lsp_edge_count, 1, "duplicate edges must not accumulate");
+    assert_eq!(
+        stats.lsp_edge_count, 1,
+        "duplicate edges must not accumulate"
+    );
 }
 
 /// LSP edges for a file are deleted when that file is re-indexed.
@@ -1305,8 +1300,12 @@ fn consolidate_observations_is_noop_without_embedder() {
     let engine = indexed_engine_with_two_langs(&dir);
 
     // Produce a few auto observations so there is something to consolidate.
-    engine.run_pipeline("rust fn", Some(4000), None, None).unwrap();
-    engine.run_pipeline("py fn", Some(4000), None, None).unwrap();
+    engine
+        .run_pipeline("rust fn", Some(4000), None, None)
+        .unwrap();
+    engine
+        .run_pipeline("py fn", Some(4000), None, None)
+        .unwrap();
 
     let n = engine
         .consolidate_observations()
@@ -1321,8 +1320,12 @@ fn consolidate_does_not_expire_observations_without_embedder() {
     let dir = tempfile::tempdir().unwrap();
     let engine = indexed_engine_with_two_langs(&dir);
 
-    engine.run_pipeline("rust fn", Some(4000), None, None).unwrap();
-    engine.run_pipeline("py fn", Some(4000), None, None).unwrap();
+    engine
+        .run_pipeline("rust fn", Some(4000), None, None)
+        .unwrap();
+    engine
+        .run_pipeline("py fn", Some(4000), None, None)
+        .unwrap();
 
     engine.consolidate_observations().unwrap();
 
@@ -1346,7 +1349,9 @@ fn consolidated_kind_not_in_candidates_pool() {
     let dir = tempfile::tempdir().unwrap();
     let engine = indexed_engine_with_two_langs(&dir);
 
-    engine.run_pipeline("rust fn", Some(4000), None, None).unwrap();
+    engine
+        .run_pipeline("rust fn", Some(4000), None, None)
+        .unwrap();
     engine.consolidate_observations().unwrap(); // no-op without embedder
 
     let obs = engine

--- a/crates/cs-mcp/src/main.rs
+++ b/crates/cs-mcp/src/main.rs
@@ -777,11 +777,7 @@ fn format_observations(
                 ));
                 if let Some(fqn) = &o.symbol_fqn {
                     if let Some((sig, body)) = engine.get_symbol_snippet(fqn) {
-                        out.push_str(&format!(
-                            "  ```\n  {}\n  {}\n  ```\n",
-                            sig.trim(),
-                            body
-                        ));
+                        out.push_str(&format!("  ```\n  {}\n  {}\n  ```\n", sig.trim(), body));
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- `cargo fmt --all` — formatting drift from squash-merged PRs (#34, #36)
- No logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)