### PR TITLE
style: rustfmt fixes for issue #14 changes

### DIFF
--- a/crates/cs-core/src/db.rs
+++ b/crates/cs-core/src/db.rs
@@ -356,9 +356,7 @@ impl Database {
 
     /// Return all (path, content_hash) pairs from the files table.
     pub fn all_file_hashes(&self) -> Result<HashMap<String, String>> {
-        let mut stmt = self
-            .conn
-            .prepare("SELECT path, content_hash FROM files")?;
+        let mut stmt = self.conn.prepare("SELECT path, content_hash FROM files")?;
         let map = stmt
             .query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))?
             .filter_map(|r| r.ok())

--- a/crates/cs-core/src/engine.rs
+++ b/crates/cs-core/src/engine.rs
@@ -460,8 +460,7 @@ impl CoreEngine {
         let manifest = Manifest {
             version: 1,
             workspace: self.config.workspace_root.to_string_lossy().to_string(),
-            updated_at: chrono::Utc::now()
-                .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            updated_at: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             files: file_hashes,
         };
         let json = serde_json::to_string_pretty(&manifest)?;
@@ -527,7 +526,11 @@ impl CoreEngine {
                     .unwrap_or(path)
                     .to_string_lossy()
                     .to_string();
-                if baseline_hashes.get(&rel).map(|h| h == &hash).unwrap_or(false) {
+                if baseline_hashes
+                    .get(&rel)
+                    .map(|h| h == &hash)
+                    .unwrap_or(false)
+                {
                     return None; // unchanged — skip
                 }
                 let symbols = index_file(&self.config.workspace_root, path, &content)

--- a/crates/cs-core/tests/engine.rs
+++ b/crates/cs-core/tests/engine.rs
@@ -1559,8 +1559,11 @@ fn incremental_index_skips_unchanged_files() {
     let count_before = stats_before.symbol_count;
 
     // Modify one file and re-index
-    std::fs::write(dir.path().join("other.rs"), "pub fn other() {}\npub fn new_fn() {}\n")
-        .unwrap();
+    std::fs::write(
+        dir.path().join("other.rs"),
+        "pub fn other() {}\npub fn new_fn() {}\n",
+    )
+    .unwrap();
     engine.index_workspace().expect("second index failed");
 
     let stats_after = engine.index_stats().expect("stats failed");
@@ -1573,7 +1576,10 @@ fn incremental_index_skips_unchanged_files() {
     let out = engine
         .run_pipeline("stable", Some(2000), None, None)
         .expect("run_pipeline failed");
-    assert!(out.contains("stable"), "unchanged symbol should still be indexed");
+    assert!(
+        out.contains("stable"),
+        "unchanged symbol should still be indexed"
+    );
 }
 
 /// `.codesurgeon/.gitignore` is created on `CoreEngine::new()` and excludes manifest.json
@@ -1607,7 +1613,10 @@ fn gitignore_omits_manifest_when_tracked() {
 
     let gitignore = dir.path().join(".codesurgeon").join(".gitignore");
     let contents = std::fs::read_to_string(&gitignore).unwrap();
-    assert!(contents.contains("index.db"), "should still exclude index.db");
+    assert!(
+        contents.contains("index.db"),
+        "should still exclude index.db"
+    );
     assert!(
         !contents.contains("manifest.json"),
         "manifest.json should not be excluded when track_manifest=true"


### PR DESCRIPTION
Fixes CI formatting failures from #39 — rustfmt reformatted 3 lines in db.rs, engine.rs, and tests/engine.rs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)