### PR TITLE
fix: P0 items from codebase review — docs + cache_size

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,10 @@ It parses your codebase into a symbol graph, then serves token-budgeted context 
 | `index_status` | Check index health |
 | `get_session_context` | See what was learned in previous sessions |
 | `save_observation` | Save an insight so it persists across sessions |
+| `search_memory` | Search saved observations by keyword |
+| `get_diff_capsule` | Context capsule scoped to a PR diff |
+| `generate_module_docs` | Auto-generate per-directory CLAUDE.md files |
+| `submit_lsp_edges` | Push LSP-resolved type edges from IDE extensions |
 | `get_stats` | Token savings, latency percentiles, intent breakdown (last N days) |
 
 ## Recommended workflow

--- a/crates/cs-core/src/db.rs
+++ b/crates/cs-core/src/db.rs
@@ -17,7 +17,7 @@ impl Database {
             "PRAGMA journal_mode=WAL; \
              PRAGMA synchronous=NORMAL; \
              PRAGMA busy_timeout=5000; \
-             PRAGMA cache_size=-65536;",
+             PRAGMA cache_size=-8192;",
         )?;
         let db = Database { conn };
         db.create_schema()?;


### PR DESCRIPTION
## Summary
- **docs: add 4 missing MCP tools to CLAUDE.md table** (closes #44) — `search_memory`, `get_diff_capsule`, `generate_module_docs`, `submit_lsp_edges` were implemented but not listed
- **perf: reduce SQLite cache_size from 256 MB to 32 MB** (closes #46) — each instance allocated a 256 MB page cache via `PRAGMA cache_size=-65536`. For bursty MCP queries, 32 MB (`-8192`) is sufficient. Saves ~220 MB per instance; for 5 concurrent workspaces that's ~1.1 GB recovered.

## Test plan
- [x] `cargo fmt --all` — no changes
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test --workspace` — all 225 tests pass
- [ ] Verify no regression on search latency after cache_size reduction (manual spot-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)