### PR TITLE
impact: cap get_impact_graph response size (#65)

### DIFF
--- a/crates/cs-cli/src/main.rs
+++ b/crates/cs-cli/src/main.rs
@@ -236,20 +236,42 @@ async fn main() -> Result<()> {
         }
 
         Commands::Impact { symbol_fqn } => {
-            let result = engine.get_impact_graph(&symbol_fqn, None, true)?;
+            let result = engine.get_impact_graph(&symbol_fqn, None, None, true)?;
             println!("Impact graph for: {}", result.target_fqn);
             println!("Total affected: {}\n", result.total_affected);
 
             if !result.direct_dependents.is_empty() {
-                println!("Direct dependents:");
+                println!(
+                    "Direct dependents ({} shown{}):",
+                    result.direct_dependents.len(),
+                    if result.direct_truncated > 0 {
+                        format!(", {} more truncated", result.direct_truncated)
+                    } else {
+                        String::new()
+                    }
+                );
                 for s in &result.direct_dependents {
                     println!("  {} ({}:{})", s.fqn, s.file_path, s.start_line);
                 }
+                if result.direct_truncated > 0 {
+                    println!("  … + {} more (truncated)", result.direct_truncated);
+                }
             }
             if !result.transitive_dependents.is_empty() {
-                println!("\nTransitive dependents:");
+                println!(
+                    "\nTransitive dependents ({} shown{}):",
+                    result.transitive_dependents.len(),
+                    if result.transitive_truncated > 0 {
+                        format!(", {} more truncated", result.transitive_truncated)
+                    } else {
+                        String::new()
+                    }
+                );
                 for s in &result.transitive_dependents {
                     println!("  {} ({}:{})", s.fqn, s.file_path, s.start_line);
+                }
+                if result.transitive_truncated > 0 {
+                    println!("  … + {} more (truncated)", result.transitive_truncated);
                 }
             }
         }

--- a/crates/cs-core/src/engine.rs
+++ b/crates/cs-core/src/engine.rs
@@ -70,6 +70,12 @@ pub struct EngineConfig {
     pub max_pivots: usize,
     pub max_adjacent: usize,
     pub max_blast_radius_depth: u32,
+    /// Per-list cap on dependents returned by `get_impact_graph`.
+    /// Applies independently to direct and transitive lists; anything beyond
+    /// is dropped and reported via `ImpactResult::{direct,transitive}_truncated`.
+    /// Default 100 keeps a worst-case response under ~5k tokens for high-fan-out
+    /// symbols (e.g. exception base classes in large codebases — see issue #65).
+    pub max_impact_results: usize,
     pub session_id: String,
     /// Whether to load the embedding model on startup.
     /// Set to false for secondary (read-only) instances to avoid loading the
@@ -171,6 +177,7 @@ impl EngineConfig {
             max_pivots: 8,
             max_adjacent: 20,
             max_blast_radius_depth: 5,
+            max_impact_results: 100,
             session_id,
             load_embedder: true,
             index_stubs: true,
@@ -253,7 +260,21 @@ pub struct ImpactResult {
     pub target_fqn: String,
     pub direct_dependents: Vec<SymbolRef>,
     pub transitive_dependents: Vec<SymbolRef>,
+    /// Total dependents that survived test/depth filtering, *before* the
+    /// per-list `max_results` cap was applied. Always reflects real-world
+    /// blast radius even when the returned lists are truncated.
     pub total_affected: usize,
+    /// Number of direct dependents dropped by the `max_results` cap.
+    /// Zero when the full list fit.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub direct_truncated: usize,
+    /// Number of transitive dependents dropped by the `max_results` cap.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub transitive_truncated: usize,
+}
+
+fn is_zero(n: &usize) -> bool {
+    *n == 0
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1429,6 +1450,7 @@ impl CoreEngine {
         &self,
         symbol_fqn: &str,
         max_depth: Option<u32>,
+        max_results: Option<usize>,
         include_tests: bool,
     ) -> Result<ImpactResult> {
         let graph = self.graph.read();
@@ -1454,9 +1476,9 @@ impl CoreEngine {
 
         let target_id = target.id;
         let depth = max_depth.unwrap_or(self.config.max_blast_radius_depth);
+        let cap = max_results.unwrap_or(self.config.max_impact_results).max(1);
 
-        let is_test = |s: &SymbolRef| -> bool {
-            let p = &s.file_path;
+        let is_test_path = |p: &str| -> bool {
             p.contains("/test")
                 || p.contains("_test.")
                 || p.contains("test_")
@@ -1464,27 +1486,43 @@ impl CoreEngine {
                 || p.contains("_spec.")
         };
 
-        let direct: Vec<SymbolRef> = graph
+        // Rank by descending centrality so the most-depended-on dependents
+        // survive truncation; FQN ascending breaks ties for stable output.
+        // Centrality is f32 in [0, 1); scale to i64 for total ordering.
+        let rank_key = |s: &Symbol| -> (i64, String) {
+            let c = (graph.centrality_score(s.id) * 1_000_000.0) as i64;
+            (-c, s.fqn.clone())
+        };
+
+        let mut direct: Vec<&Symbol> = graph
             .dependents(target_id)
             .into_iter()
-            .map(sym_ref)
-            .filter(|s| include_tests || !is_test(s))
+            .filter(|s| include_tests || !is_test_path(&s.file_path))
             .collect();
+        direct.sort_by_cached_key(|s| rank_key(s));
+        let direct_total = direct.len();
+        let direct_truncated = direct_total.saturating_sub(cap);
+        direct.truncate(cap);
+        let direct_refs: Vec<SymbolRef> = direct.into_iter().map(sym_ref).collect();
 
-        let transitive: Vec<SymbolRef> = graph
+        let mut transitive: Vec<&Symbol> = graph
             .blast_radius(target_id, depth)
             .into_iter()
-            .map(sym_ref)
-            .filter(|s| include_tests || !is_test(s))
+            .filter(|s| include_tests || !is_test_path(&s.file_path))
             .collect();
-
-        let total = direct.len() + transitive.len();
+        transitive.sort_by_cached_key(|s| rank_key(s));
+        let transitive_total = transitive.len();
+        let transitive_truncated = transitive_total.saturating_sub(cap);
+        transitive.truncate(cap);
+        let transitive_refs: Vec<SymbolRef> = transitive.into_iter().map(sym_ref).collect();
 
         Ok(ImpactResult {
             target_fqn: symbol_fqn.to_string(),
-            direct_dependents: direct,
-            transitive_dependents: transitive,
-            total_affected: total,
+            direct_dependents: direct_refs,
+            transitive_dependents: transitive_refs,
+            total_affected: direct_total + transitive_total,
+            direct_truncated,
+            transitive_truncated,
         })
     }
 

--- a/crates/cs-core/tests/engine.rs
+++ b/crates/cs-core/tests/engine.rs
@@ -160,10 +160,10 @@ fn get_impact_graph_exclude_tests_filters_test_files() {
     engine.index_workspace().expect("index failed");
 
     let with_tests = engine
-        .get_impact_graph("lib.rs::target", None, true)
+        .get_impact_graph("lib.rs::target", None, None, true)
         .unwrap();
     let without_tests = engine
-        .get_impact_graph("lib.rs::target", None, false)
+        .get_impact_graph("lib.rs::target", None, None, false)
         .unwrap();
     for dep in &without_tests.direct_dependents {
         assert!(
@@ -188,15 +188,60 @@ fn get_impact_graph_max_depth_limits_traversal() {
     engine.index_workspace().expect("index failed");
 
     let shallow = engine
-        .get_impact_graph("lib.rs::base", Some(1), true)
+        .get_impact_graph("lib.rs::base", Some(1), None, true)
         .unwrap();
     let deep = engine
-        .get_impact_graph("lib.rs::base", Some(5), true)
+        .get_impact_graph("lib.rs::base", Some(5), None, true)
         .unwrap();
     assert!(
         shallow.total_affected <= deep.total_affected,
         "shallow traversal should find ≤ symbols than deep"
     );
+}
+
+/// `get_impact_graph` must cap each list at `max_results` for high-fan-out
+/// symbols and report the dropped count via `direct_truncated`. Without this
+/// cap, central symbols (e.g. exception base classes) overflow agent context —
+/// see issue #65, where `PolynomialError` returned 30k+ transitive dependents.
+#[test]
+fn get_impact_graph_caps_direct_dependents_for_high_fanout() {
+    let dir = tempfile::tempdir().unwrap();
+    // 1 target + 60 distinct callers all in one file.
+    let mut src = String::from("pub fn target() {}\n");
+    for i in 0..60 {
+        src.push_str(&format!("pub fn caller_{i:02}() {{ target(); }}\n"));
+    }
+    std::fs::write(dir.path().join("lib.rs"), src).unwrap();
+    let engine = test_engine(&dir);
+    engine.index_workspace().expect("index failed");
+
+    let result = engine
+        .get_impact_graph("lib.rs::target", None, Some(10), true)
+        .expect("get_impact_graph failed");
+
+    assert_eq!(
+        result.direct_dependents.len(),
+        10,
+        "direct list must respect the max_results cap"
+    );
+    assert_eq!(
+        result.direct_truncated, 50,
+        "direct_truncated must report dropped count: 60 callers - 10 cap"
+    );
+    // total_affected must reflect the *real* blast radius, not the truncated view.
+    assert!(
+        result.total_affected >= 60,
+        "total_affected must be the pre-cap count, got {}",
+        result.total_affected
+    );
+
+    // Cap is stable: a second call returns the same set in the same order.
+    let again = engine
+        .get_impact_graph("lib.rs::target", None, Some(10), true)
+        .unwrap();
+    let first: Vec<_> = result.direct_dependents.iter().map(|s| &s.fqn).collect();
+    let second: Vec<_> = again.direct_dependents.iter().map(|s| &s.fqn).collect();
+    assert_eq!(first, second, "truncation order must be deterministic");
 }
 
 /// `get_skeleton` with `max_depth=1` must return only top-level symbols.

--- a/crates/cs-mcp/src/main.rs
+++ b/crates/cs-mcp/src/main.rs
@@ -16,7 +16,12 @@
 //! ```
 
 use anyhow::Result;
-use cs_core::{engine::EngineConfig, symbol::LspEdge, watcher::FileWatcher, CoreEngine};
+use cs_core::{
+    engine::{EngineConfig, ImpactResult, SymbolRef},
+    symbol::LspEdge,
+    watcher::FileWatcher,
+    CoreEngine,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
@@ -154,6 +159,10 @@ fn tool_list() -> Value {
                         "max_depth": {
                             "type": "integer",
                             "description": "Maximum traversal depth for transitive dependents (default: 5)"
+                        },
+                        "max_results": {
+                            "type": "integer",
+                            "description": "Per-list cap on dependents (default: 100). High-fan-out symbols (e.g. exception base classes) can have thousands of transitive dependents — the cap keeps the response under ~5k tokens. Highest-centrality dependents are preserved when truncation fires; truncation count is reported in the response."
                         },
                         "include_tests": {
                             "type": "boolean",
@@ -862,9 +871,16 @@ async fn dispatch_tool(engine: &Arc<CoreEngine>, name: &str, args: &Value) -> Re
         "get_impact_graph" => {
             let fqn = string_arg(&args, "symbol_fqn")?;
             let max_depth = args.get("max_depth").and_then(|v| v.as_u64()).map(|v| v as u32);
-            let include_tests = args.get("include_tests").and_then(|v| v.as_bool()).unwrap_or(true);
-            let result = engine.get_impact_graph(&fqn, max_depth, include_tests)?;
-            Ok(serde_json::to_string_pretty(&result)?)
+            let max_results = args
+                .get("max_results")
+                .and_then(|v| v.as_u64())
+                .map(|v| v as usize);
+            let include_tests = args
+                .get("include_tests")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true);
+            let result = engine.get_impact_graph(&fqn, max_depth, max_results, include_tests)?;
+            Ok(format_impact(&result))
         }
 
         "get_skeleton" => {
@@ -1034,6 +1050,54 @@ async fn dispatch_tool(engine: &Arc<CoreEngine>, name: &str, args: &Value) -> Re
         other => Err(anyhow::anyhow!("Unknown tool: {}", other)),
     })
     .await?
+}
+
+/// Render `ImpactResult` as a compact markdown report. Truncation is reported
+/// inline with the kept count and the dropped count so callers can see at a
+/// glance whether the cap fired and what the real blast radius is.
+fn format_impact(r: &ImpactResult) -> String {
+    let mut out = format!(
+        "## Impact graph: {}\n\nTotal affected: {}\n\n",
+        r.target_fqn, r.total_affected
+    );
+
+    let render_section = |out: &mut String, label: &str, deps: &[SymbolRef], truncated: usize| {
+        let kept = deps.len();
+        if kept == 0 && truncated == 0 {
+            return;
+        }
+        out.push_str(&format!("### {label} ({kept} shown"));
+        if truncated > 0 {
+            out.push_str(&format!(", {truncated} more truncated"));
+        }
+        out.push_str(")\n");
+        for s in deps {
+            out.push_str(&format!(
+                "- `{}` ({}:{})\n",
+                s.fqn, s.file_path, s.start_line
+            ));
+        }
+        if truncated > 0 {
+            out.push_str(&format!(
+                "- … + {truncated} more (truncated; pass higher `max_results` to see more, or filter by depth)\n"
+            ));
+        }
+        out.push('\n');
+    };
+
+    render_section(
+        &mut out,
+        "Direct dependents",
+        &r.direct_dependents,
+        r.direct_truncated,
+    );
+    render_section(
+        &mut out,
+        "Transitive dependents",
+        &r.transitive_dependents,
+        r.transitive_truncated,
+    );
+    out
 }
 
 fn string_arg(args: &Value, key: &str) -> Result<String> {

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -382,6 +382,7 @@ identifies the coordinator. Requires `>= 2` owned seed types to avoid false posi
 | max_pivots | 8 | `engine.rs` |
 | max_adjacent | 20 | `engine.rs` |
 | max_blast_radius_depth | 5 | `engine.rs` |
+| max_impact_results (per-list cap) | 100 | `engine.rs` |
 | family_in_degree k | 5 | `graph.rs` |
 | centrality_score k | 15 | `graph.rs` |
 | Stub score weight | × 0.3 | `ranking.rs:STUB_SCORE_WEIGHT` |


### PR DESCRIPTION
## Summary
- Cap each `get_impact_graph` list at `max_results` (default 100, configurable per-call and via `EngineConfig.max_impact_results`); sort dependents by descending centrality with stable FQN tiebreak so highest-impact hits survive truncation.
- `ImpactResult` gains `direct_truncated` / `transitive_truncated`; `total_affected` keeps reporting the real pre-cap blast radius so agents still see the true blast.
- MCP layer renders the result as markdown with explicit `(N shown, M more truncated)` headings and a trailing `… + M more (truncated)` marker, replacing the raw JSON dump that previously flooded agent context. CLI gets the same marker.

Fixes #65 (Option 1, the unblocker). Phase 4 sympy rerun is left to the user.

## Test plan
- [x] `cargo test -p cs-core --test engine` — 83 pass, including new fan-out test (60 callers, cap=10) asserting cap fires, `direct_truncated == 50`, `total_affected ≥ 60`, and order is deterministic across calls.
- [x] `cargo test -p cs-mcp --test mcp_protocol` — 16 pass.
- [x] `cargo test --workspace` — all 303 pass.
- [x] `cargo fmt --check` and `cargo clippy --workspace -- -D warnings` clean.
- [ ] Phase 4 SWE-bench rerun on `sympy__sympy-21379` finishes within 600 s and produces a fix at `sympy/core/mod.py::Mod.eval` (out of scope for this PR; tracked on the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)