### PR TITLE
swebench: --resume flag to skip pairs already in results.jsonl

### DIFF
--- a/benches/swebench/run.py
+++ b/benches/swebench/run.py
@@ -1272,6 +1272,29 @@ def append_result(path: Path, result: RunResult) -> None:
         f.write(json.dumps(asdict(result)) + "\n")
 
 
+def load_completed_pairs(path: Path) -> set[tuple[str, str]]:
+    """Read results.jsonl and return the set of (instance_id, arm) already done.
+
+    Used by ``--resume`` to skip pairs that have already been recorded so an
+    interrupted run can pick up exactly where it left off. Malformed rows
+    (truncated writes, missing fields) are skipped silently.
+    """
+    done: set[tuple[str, str]] = set()
+    if not path.exists():
+        return done
+    with path.open() as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+                done.add((row["instance_id"], row["arm"]))
+            except (json.JSONDecodeError, KeyError):
+                continue
+    return done
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--tasks", type=int, default=None, help="run only first N tasks")
@@ -1306,6 +1329,11 @@ def main() -> int:
         help=f"results.jsonl output path (default: {RESULTS_PATH.relative_to(REPO_ROOT)})",
     )
     parser.add_argument("--clean", action="store_true", help="truncate results.jsonl before running")
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="skip (task, arm) pairs already in results.jsonl — use to continue an interrupted run",
+    )
     parser.add_argument(
         "--inject-claude-md",
         action="store_true",
@@ -1387,6 +1415,10 @@ def main() -> int:
     elif args.tasks is not None:
         tasks = tasks[: args.tasks]
 
+    if args.clean and args.resume:
+        print("--clean and --resume are mutually exclusive", file=sys.stderr)
+        return 2
+
     print(
         f"running {len(tasks)} tasks × {len(arms)} arms ({'dry-run' if args.dry_run else 'live'}) → {args.results.relative_to(REPO_ROOT) if args.results.is_relative_to(REPO_ROOT) else args.results}",
         file=sys.stderr,
@@ -1397,8 +1429,19 @@ def main() -> int:
 
     results_dir = args.results.parent
 
+    done = load_completed_pairs(args.results) if args.resume else set()
+    if done:
+        total_pairs = len(tasks) * len(arms)
+        skipped = sum(1 for t in tasks for a in arms if (t["instance_id"], a) in done)
+        print(
+            f"  resume: {skipped}/{total_pairs} pairs already done, {total_pairs - skipped} remaining",
+            file=sys.stderr,
+        )
+
     for task in tasks:
         for arm in arms:
+            if (task["instance_id"], arm) in done:
+                continue
             result = run_one(
                 task=task,
                 arm=arm,


### PR DESCRIPTION
## Summary

Long pilot runs (50+ tasks × 2 arms × 5–15 min each) are interrupted often — quota hits, system reboots, network blips. Today the only options are restart from scratch (re-paying every completed task) or manually elide done tasks from \`tasks.json\`. This adds an opt-in \`--resume\` flag that reads \`results.jsonl\`, reconstructs the set of already-recorded \`(instance_id, arm)\` pairs, and skips them in the main loop.

### Behaviour

- \`load_completed_pairs\` is defensive: missing file → empty set; malformed/truncated rows are skipped silently. This matters because a crashed harness can leave a partial last line in \`results.jsonl\`.
- \`--clean\` and \`--resume\` are mutually exclusive (clean truncates the file resume needs). Exit 2 with an explanatory message.
- Drive-by: moved the mutex check above the "running N tasks × M arms" status print so a rejected invocation doesn't print a misleading line before bailing.

### Scope note

The original WIP branch also included \`looks_like_transient_error()\` to classify failures into quota/network blips vs real errors. That classifier only has a caller in the bigger main-loop retry restructure (a later PR), so adding it now would be dead code. Pulled it forward into the retry PR instead.

## Test plan

- [x] **Unit, 4 cases** for \`load_completed_pairs\`:
  - missing file → empty set
  - well-formed jsonl (3 rows) → 3 pairs
  - malformed rows (bad JSON, missing keys, blank lines) skipped → only valid pairs returned
  - truncated last line (interrupted write) tolerated
- [x] **CLI end-to-end:** pre-seeded 4 rows (2 tasks × 2 arms), \`--resume --dry-run\` over 5 tasks × 2 arms confirmed exactly the 6 remaining pairs ran. Output: \`resume: 4/10 pairs already done, 6 remaining\`.
- [x] **Baseline:** without \`--resume\`, all 10 pairs ran.
- [x] **Mutex:** \`--clean --resume\` → \`exit 2\` with \`--clean and --resume are mutually exclusive\`.
- [ ] Reviewer to spot-check that the skip-and-continue inside the existing double-for is semantically equivalent to the WIP's \`all_pairs\` restructure (it should be — restructure was driven by prefetch look-ahead, not resume).

Fourth slice off the WIP rescue branch [\`claude/recursing-jang-ca33f9\`](https://github.com/subsriram/codesurgeon/tree/claude/recursing-jang-ca33f9). Independent of #84/#85/#86 — touches \`main()\` in \`run.py\`, different region from #85's \`clone_task_repo\` and #86's \`run_one\` indexing path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)