### PR TITLE
swebench: stream claude stderr to a file instead of capture_output

### DIFF
--- a/benches/swebench/run.py
+++ b/benches/swebench/run.py
@@ -787,6 +787,22 @@ def build_claude_cmd(
     return cmd
 
 
+def _read_tail(path: Path, n_bytes: int) -> str:
+    """Return the last ``n_bytes`` of ``path`` as UTF-8 text, or "" if missing.
+
+    Seeks rather than reading the whole file so multi-MB stderr logs (cs_core
+    debug output over a multi-hour task) don't have to be loaded into memory
+    just to extract a 2 KB tail for the error message.
+    """
+    if not path.exists():
+        return ""
+    size = path.stat().st_size
+    with path.open("rb") as f:
+        if size > n_bytes:
+            f.seek(-n_bytes, 2)
+        return f.read().decode("utf-8", errors="replace")
+
+
 def parse_claude_json(stdout: str, stream_json: bool = False) -> dict:
     """Extract the structured result from ``claude --print`` output.
 
@@ -1152,31 +1168,44 @@ def run_one(
                 error=None,
             )
 
+        # Pre-create the artifact dir so stderr can stream to a file rather
+        # than be buffered in memory. Under cs_core=debug the MCP sidecar
+        # logs run into the megabytes over a long task; capture_output would
+        # hold all of that in process RSS for the duration. The file is
+        # later kept as `claude.stderr` next to the other per-task artifacts.
+        artifact_base = results_dir / arm / task["instance_id"]
+        artifact_base.mkdir(parents=True, exist_ok=True)
+        stderr_path = artifact_base / "claude.stderr"
+
         t0 = time.monotonic()
         try:
             try:
-                proc = subprocess.run(
-                    cmd,
-                    capture_output=True,
-                    text=True,
-                    timeout=timeout_s,
-                    cwd=workdir,
-                )
+                with stderr_path.open("wb") as stderr_f:
+                    proc = subprocess.run(
+                        cmd,
+                        stdout=subprocess.PIPE,
+                        stderr=stderr_f,
+                        text=True,
+                        timeout=timeout_s,
+                        cwd=workdir,
+                    )
                 exit_code = proc.returncode
                 stdout = proc.stdout
-                stderr_tail = proc.stderr[-2000:] if proc.stderr else ""
+                stderr_tail = _read_tail(stderr_path, 2000)
                 err_msg = None if exit_code == 0 else f"exit={exit_code}; stderr-tail={stderr_tail}"
             except subprocess.TimeoutExpired as e:
-                # Preserve whatever was captured before the kill so the partial
-                # stream (stream-json mode) can be inspected post-mortem —
-                # otherwise a timed-out run is a total black box.
+                # Preserve whatever stdout was captured before the kill so the
+                # partial stream (stream-json mode) can be inspected
+                # post-mortem — otherwise a timed-out run is a total black
+                # box. Stderr is on disk already (file-piped above); just
+                # read its tail.
                 #
-                # `subprocess.TimeoutExpired.stdout` / `.stderr` are **bytes**
-                # on Python 3.14, regardless of `text=True` on `run()`. (A
-                # completed `proc.stdout` under `text=True` is `str`; the
-                # exception attrs are not decoded by the same path.) Decode
-                # defensively so downstream code that expects `str` (e.g.
-                # `Path.write_text`) doesn't crash.
+                # `subprocess.TimeoutExpired.stdout` is **bytes** on Python
+                # 3.14, regardless of `text=True` on `run()`. (A completed
+                # `proc.stdout` under `text=True` is `str`; the exception
+                # attr is not decoded by the same path.) Decode defensively
+                # so downstream code that expects `str` (e.g. `Path.write_text`)
+                # doesn't crash.
                 def _decode(x: object) -> str:
                     if x is None:
                         return ""
@@ -1186,11 +1215,11 @@ def run_one(
 
                 exit_code = -2
                 stdout = _decode(e.stdout)
-                partial_stderr = _decode(e.stderr)
-                stderr_tail = partial_stderr[-2000:]
+                stderr_size = stderr_path.stat().st_size if stderr_path.exists() else 0
+                stderr_tail = _read_tail(stderr_path, 2000)
                 err_msg = (
                     f"timeout after {timeout_s}s "
-                    f"(captured {len(stdout)} B stdout, {len(partial_stderr)} B stderr)"
+                    f"(captured {len(stdout)} B stdout, {stderr_size} B stderr)"
                 )
         finally:
             # Always reap the sidecar MCP, even on timeout / exception.
@@ -1211,8 +1240,8 @@ def run_one(
         #   - `archive/<isotime>_*` — permanent per-run copies so
         #     subsequent runs don't overwrite them. Preserves the stream
         #     for every configuration tried on the same task.
-        artifact_base = results_dir / arm / task["instance_id"]
-        artifact_base.mkdir(parents=True, exist_ok=True)
+        # `artifact_base` was created above before the subprocess.run so
+        # stderr could stream into it; just ensure the archive subdir exists.
         archive_dir = artifact_base / "archive"
         archive_dir.mkdir(exist_ok=True)
         run_ts = datetime.datetime.now().isoformat(timespec="seconds").replace(":", "-")


### PR DESCRIPTION
## Summary

Under \`cs_core=debug\` logging (PR #84), the codesurgeon MCP sidecar's stderr can run into the megabytes over a multi-hour task. \`capture_output\` holds all of that in process RSS for the duration; over 50+ tasks this is real memory pressure.

This pipes stderr to a per-task \`claude.stderr\` file under the same artifact dir as \`patch.diff\` and \`claude_stream.jsonl\`, then seek-reads the last 2 KB into the existing \`stderr_tail\` slot in \`error\`. The file is also useful post-mortem: timeouts and quota errors previously truncated stderr to 2000 bytes; now the full transcript survives.

A small \`_read_tail(path, n_bytes)\` helper seeks to end-of-file rather than reading the whole thing — a 200 MB stderr log shouldn't be loaded into memory just to extract a tail.

### Behaviour notes

- \`artifact_base\` directory is created before the \`subprocess.run\` rather than after. Early-return paths (clone fail, index fail, preflight fail) still don't create it — the mkdir was moved to just before the run, after every early return.
- The timeout salvage path still decodes \`TimeoutExpired.stdout\` defensively (bytes-vs-str on Python 3.14). \`e.stderr\` is now \`None\` because we redirected, so we read from the file instead.
- The \`(captured X B stdout, Y B stderr)\` timeout message reports on-disk stderr size rather than the in-memory partial.

### Scope note

This is the **only** piece worth pulling forward from the WIP rescue branch's "stream-JSON refactor" chunk. The rest of that chunk (renaming \`RunResult.claude_json_path\` → \`stream_path\`, dropping the \`--output-format json\` mode) was obsoleted by main's cleaner opt-in \`--stream-json\` design that landed independently. Skipping all of it.

## Test plan

- [x] **\`_read_tail\` unit cases:** missing file, small file (< n), large file (> n returns last n bytes), invalid UTF-8 (decoded with \`errors='replace'\`).
- [x] **E2E success path:** subprocess writes 2801 B stderr; file captures all of it; tail extraction returns the last 2000 B.
- [x] **E2E timeout path:** subprocess prints partial stdout + stderr then blocks on sleep; \`TimeoutExpired.stdout\` salvaged and decoded; stderr file captures partial content correctly.
- [x] \`uv run benches/swebench/run.py --dry-run\` still passes.
- [ ] Reviewer to confirm: in this scope, is opening \`stderr_path\` in \`"wb"\` mode correct? (subprocess writes via the underlying fd, so bytes mode is the conservative choice; the WIP used \`"w"\` which also works but mixes Python text-mode wrapping with raw fd writes.)
- [ ] Reviewer to confirm: per-task \`claude.stderr\` files under \`target/swebench/<arm>/<instance_id>/\` are gitignored (target/ is) and acceptable as new persistent artifacts.

Fifth slice off the WIP rescue branch [\`claude/recursing-jang-ca33f9\`](https://github.com/subsriram/codesurgeon/tree/claude/recursing-jang-ca33f9). Independent of #84/#85/#86/#87 — touches only the subprocess block in \`run_one\`, no overlap with prior PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)