### PR TITLE
ranking: derive centrality smoothing constant k from corpus (#82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,17 +452,18 @@ ln -s /path/to/codesurgeon/target/release/codesurgeon /usr/local/bin/codesurgeon
 
 ### Enabling debug logging
 
-Set `RUST_LOG` to see detailed output from the MCP server or CLI:
+Set `CS_LOG` (a [`tracing-subscriber`](https://docs.rs/tracing-subscriber) env-filter
+expression) to see detailed output from the MCP server or CLI. Default: `warn`.
 
 ```bash
 # Info-level (recommended for troubleshooting)
-RUST_LOG=info CS_WORKSPACE=/path/to/project codesurgeon query "my search"
+CS_LOG=info CS_WORKSPACE=/path/to/project codesurgeon query "my search"
 
 # Debug-level (verbose — shows every file indexed, every query scored)
-RUST_LOG=debug CS_WORKSPACE=/path/to/project ./target/release/codesurgeon-mcp
+CS_LOG=debug CS_WORKSPACE=/path/to/project ./target/release/codesurgeon-mcp
 
 # Trace a specific module
-RUST_LOG=cs_core::engine=debug codesurgeon query "my search"
+CS_LOG=cs_core::engine=debug codesurgeon query "my search"
 ```
 
 ## Configuration
@@ -513,6 +514,19 @@ token_rate_usd = 0.000003
 ```
 
 Run `codesurgeon config` to see the effective merged settings and their sources.
+
+## Environment variables
+
+Most settings live in `config.toml` (above). The following env vars control
+runtime concerns that don't belong in committed config:
+
+| Var | Read by | Purpose |
+|---|---|---|
+| `CS_WORKSPACE` | `codesurgeon`, `codesurgeon-mcp` | Workspace root for indexing and queries. Required when not running from inside the workspace. |
+| `CLAUDE_CODE_WORKSPACE` | `codesurgeon`, `codesurgeon-mcp` | Alias of `CS_WORKSPACE`, set automatically by Claude Code. `CS_WORKSPACE` wins if both are set. |
+| `CS_LOG` | `codesurgeon`, `codesurgeon-mcp` | [`tracing-subscriber`](https://docs.rs/tracing-subscriber) env-filter expression (e.g. `info`, `debug`, `cs_core::engine=trace`). Default: `warn`. |
+| `CS_TRACK_MANIFEST` | `codesurgeon`, `codesurgeon-mcp` | Set to `1` to overlay `[git] track_manifest = true` from the environment, omitting `manifest.json` from `.codesurgeon/.gitignore` so it can be shared across clones. |
+| `CS_BENCH_CENTRALITY_K` | `cargo run --example token_savings` | Pin the centrality smoothing constant `k` for the 20-query bench, e.g. `CS_BENCH_CENTRALITY_K=15.0` reproduces pre-#82 behaviour. Unset → corpus-derived (default). Bench-only — has no effect on the binaries. |
 
 ## Contributing
 

--- a/crates/cs-cli/src/main.rs
+++ b/crates/cs-cli/src/main.rs
@@ -149,6 +149,12 @@ async fn main() -> Result<()> {
             println!("Edges   : {}", stats.edge_count);
             println!("Files   : {}", stats.file_count);
             println!("Session : {}", stats.session_id);
+            let source = if stats.centrality_k_overridden {
+                "config override".to_string()
+            } else {
+                format!("p{:.0} of corpus", stats.centrality_k_percentile * 100.0)
+            };
+            println!("Cent. k : {:.2} ({})", stats.centrality_k, source);
         }
 
         Commands::Search { query, budget } => {

--- a/crates/cs-core/examples/token_savings.rs
+++ b/crates/cs-core/examples/token_savings.rs
@@ -13,6 +13,10 @@
 //!
 //! Usage:
 //!     cargo run --release --example token_savings -p cs-core
+//!
+//! Honoured env vars (see README §"Environment variables"):
+//!   - `CS_BENCH_CENTRALITY_K` — pin the centrality smoothing constant `k`
+//!     (e.g. `15.0` reproduces pre-#82 behaviour for A/B comparison).
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/cs-core/examples/token_savings.rs
+++ b/crates/cs-core/examples/token_savings.rs
@@ -93,7 +93,15 @@ fn main() {
         .expect("tempdir");
     copy_dir(&corpus_source(), &tmp.path().join("src"));
 
-    let cfg = EngineConfig::new(tmp.path()).without_embedder();
+    let mut cfg = EngineConfig::new(tmp.path()).without_embedder();
+    // A/B knob: set CS_BENCH_CENTRALITY_K=15.0 to pin the smoothing constant
+    // and reproduce pre-#82 behaviour for comparison runs. Unset → corpus
+    // median (issue #82 default).
+    if let Ok(s) = std::env::var("CS_BENCH_CENTRALITY_K") {
+        if let Ok(k) = s.parse::<f32>() {
+            cfg.centrality_k_override = Some(k);
+        }
+    }
     let engine = CoreEngine::new(cfg).expect("engine");
     engine.index_workspace().expect("index");
 

--- a/crates/cs-core/src/engine.rs
+++ b/crates/cs-core/src/engine.rs
@@ -156,6 +156,24 @@ pub struct EngineConfig {
     /// to opt into the pre-#72 behaviour. Explicit `save_observation` calls
     /// (agent-attested memory) are unaffected.
     pub auto_observations: bool,
+
+    /// Percentile of the raw-degree distribution (`in*2 + out`) used to derive
+    /// the smoothing constant `k` in `CodeGraph::centrality_score`. The value
+    /// at this percentile becomes `k`, so the symbol at that percentile scores
+    /// 0.5. Default: 0.5 (median).
+    ///
+    /// Set via `[ranking] centrality_k_percentile = 0.75` in `config.toml`.
+    /// Range `[0.0, 1.0]`; out-of-range values are clamped.
+    /// Ignored when `centrality_k_override` is set.
+    pub centrality_k_percentile: f32,
+
+    /// Optional explicit override for the centrality smoothing constant `k`.
+    /// When `Some(k)`, the percentile derivation is skipped and `k` is pinned.
+    /// Useful for reproducing pre-#82 behaviour (`Some(15.0)`) or for ablation
+    /// studies. Default: `None` (corpus-derived).
+    ///
+    /// Set via `[ranking] centrality_k = 15.0` in `config.toml`.
+    pub centrality_k_override: Option<f32>,
 }
 
 /// Controls adjacent-symbol body fraction in context capsules.
@@ -215,6 +233,8 @@ impl EngineConfig {
             token_rate_usd: 0.000003,
             reverse_expand_anchors: true,
             auto_observations: false,
+            centrality_k_percentile: crate::graph::DEFAULT_CENTRALITY_K_PERCENTILE,
+            centrality_k_override: None,
         }
     }
 
@@ -271,6 +291,17 @@ pub struct IndexStats {
     pub manifest_file_count: Option<u64>,
     /// ISO-8601 timestamp from the manifest's `updated_at` field, if present.
     pub manifest_updated_at: Option<String>,
+    /// Smoothing constant currently in use by `CodeGraph::centrality_score`.
+    /// Either derived from the corpus degree distribution at index time, or
+    /// pinned via `[ranking] centrality_k` in `config.toml`. Reported so the
+    /// chosen value is observable from `index_status` / `get_stats`.
+    pub centrality_k: f32,
+    /// Percentile of the raw-degree distribution used to derive `centrality_k`.
+    /// Reflects the configured value; ignored at runtime when an override is set.
+    pub centrality_k_percentile: f32,
+    /// True when `[ranking] centrality_k` pinned the value, bypassing the
+    /// corpus-derived percentile.
+    pub centrality_k_overridden: bool,
 }
 
 /// Return value of `get_session_context`.
@@ -391,6 +422,16 @@ impl CoreEngine {
         let graph = Arc::new(RwLock::new(CodeGraph::new()));
         let search = Arc::new(Mutex::new(SearchIndex::new()?));
 
+        // Apply caller-supplied ranking config to the freshly-built graph
+        // before any `warm_caches()` call. (Workspace-level overrides from
+        // `.codesurgeon/config.toml` are applied a few lines below, after
+        // `IndexingConfig` is loaded.)
+        {
+            let mut g = graph.write();
+            g.set_centrality_k_percentile(config.centrality_k_percentile);
+            g.set_centrality_k_override(config.centrality_k_override);
+        }
+
         // Load optional configs from .codesurgeon/config.toml
         let config_path = config
             .workspace_root
@@ -426,6 +467,19 @@ impl CoreEngine {
         }
         if indexing_config.auto_observations {
             config.auto_observations = true;
+        }
+        if let Some(p) = indexing_config.centrality_k_percentile {
+            config.centrality_k_percentile = p;
+        }
+        if let Some(k) = indexing_config.centrality_k_override {
+            config.centrality_k_override = Some(k);
+        }
+        // Re-apply ranking config to the graph in case the workspace TOML
+        // overrode the caller-supplied defaults above.
+        {
+            let mut g = graph.write();
+            g.set_centrality_k_percentile(config.centrality_k_percentile);
+            g.set_centrality_k_override(config.centrality_k_override);
         }
 
         // Write .codesurgeon/.gitignore if absent, excluding index.db always
@@ -1744,6 +1798,7 @@ impl CoreEngine {
     pub fn index_stats(&self) -> Result<IndexStats> {
         let db = self.db.lock();
         let manifest = self.read_manifest();
+        let centrality_k = self.graph.read().centrality_k();
         Ok(IndexStats {
             symbol_count: db.symbol_count()?,
             edge_count: db.edge_count()?,
@@ -1754,6 +1809,9 @@ impl CoreEngine {
             xcode_mcp_available: detect_xcode_mcp(),
             manifest_file_count: manifest.as_ref().map(|m| m.files.len() as u64),
             manifest_updated_at: manifest.map(|m| m.updated_at),
+            centrality_k,
+            centrality_k_percentile: self.config.centrality_k_percentile,
+            centrality_k_overridden: self.config.centrality_k_override.is_some(),
         })
     }
 

--- a/crates/cs-core/src/graph.rs
+++ b/crates/cs-core/src/graph.rs
@@ -3,6 +3,20 @@ use petgraph::graph::{DiGraph, NodeIndex};
 use petgraph::Direction;
 use std::collections::HashMap;
 
+/// Default smoothing constant used for the centrality formula when the graph is
+/// empty (or no override is configured). Matches the historical hardcoded value
+/// for backwards-compatible behaviour on tiny / fresh indexes.
+pub const DEFAULT_CENTRALITY_K: f32 = 15.0;
+
+/// Default percentile of the raw-degree distribution used to derive `k` at
+/// `warm_caches()` time. 0.5 ⇒ the median symbol scores 0.5.
+pub const DEFAULT_CENTRALITY_K_PERCENTILE: f32 = 0.5;
+
+/// Floor for the corpus-derived `k`. With many leaf symbols the chosen
+/// percentile of `raw = in*2 + out` can be 0; dividing by `raw + 0` collapses
+/// the score to 1.0 for any non-leaf, so we clamp.
+const CENTRALITY_K_FLOOR: f32 = 1.0;
+
 /// The in-memory dependency graph.
 /// Nodes = Symbols, Edges = EdgeKind relationships.
 pub struct CodeGraph {
@@ -13,6 +27,18 @@ pub struct CodeGraph {
     centrality_cache: Option<HashMap<u64, f32>>,
     /// Cached family in-degree scores (symbol id → score). Invalidated on mutation.
     family_in_degree_cache: Option<HashMap<u64, f32>>,
+    /// Smoothing constant for `centrality_score`. Either derived from the
+    /// degree distribution at `warm_caches()` time (the default), or pinned to
+    /// a fixed value when the operator overrides it via config. See
+    /// `centrality_score` for how it's used.
+    centrality_k: f32,
+    /// Percentile of `raw = in*2 + out` used to derive `centrality_k` during
+    /// `warm_caches()`. Range `[0.0, 1.0]`. Ignored when `centrality_k_override`
+    /// is set.
+    centrality_k_percentile: f32,
+    /// When `Some(k)`, `warm_caches()` skips the percentile derivation and
+    /// pins `centrality_k` to this value. Used for `[ranking] centrality_k = N`.
+    centrality_k_override: Option<f32>,
 }
 
 impl CodeGraph {
@@ -22,7 +48,30 @@ impl CodeGraph {
             id_to_idx: HashMap::new(),
             centrality_cache: None,
             family_in_degree_cache: None,
+            centrality_k: DEFAULT_CENTRALITY_K,
+            centrality_k_percentile: DEFAULT_CENTRALITY_K_PERCENTILE,
+            centrality_k_override: None,
         }
+    }
+
+    /// Configure the percentile of the raw-degree distribution used to derive
+    /// `centrality_k` at `warm_caches()` time. Values outside `[0.0, 1.0]` are
+    /// clamped. Takes effect on the next `warm_caches()` call.
+    pub fn set_centrality_k_percentile(&mut self, percentile: f32) {
+        self.centrality_k_percentile = percentile.clamp(0.0, 1.0);
+    }
+
+    /// Pin `centrality_k` to a fixed value, bypassing percentile derivation.
+    /// `Some(k)` overrides; `None` re-enables corpus-derived `k`. Takes effect
+    /// on the next `warm_caches()` call.
+    pub fn set_centrality_k_override(&mut self, k: Option<f32>) {
+        self.centrality_k_override = k.map(|v| v.max(CENTRALITY_K_FLOOR));
+    }
+
+    /// Current `k` used in `centrality_score`. Reflects the value from the
+    /// most recent `warm_caches()` call (or the default if it hasn't run yet).
+    pub fn centrality_k(&self) -> f32 {
+        self.centrality_k
     }
 
     /// Invalidate cached scores. Called after any graph mutation.
@@ -33,8 +82,9 @@ impl CodeGraph {
 
     /// Populate centrality and family in-degree caches in a single O(V+E) pass.
     pub fn warm_caches(&mut self) {
-        // Centrality cache
-        let centrality: HashMap<u64, f32> = self
+        // ── 1. Compute raw scores once and reuse for both `k` derivation
+        //       and per-symbol centrality.
+        let raw_scores: HashMap<u64, f32> = self
             .id_to_idx
             .iter()
             .map(|(&id, &idx)| {
@@ -46,9 +96,30 @@ impl CodeGraph {
                     .graph
                     .neighbors_directed(idx, Direction::Outgoing)
                     .count() as f32;
-                let raw = in_deg * 2.0 + out_deg;
-                (id, raw / (raw + 15.0))
+                (id, in_deg * 2.0 + out_deg)
             })
+            .collect();
+
+        // ── 2. Pick `k`: explicit override wins; otherwise derive from the
+        //       configured percentile of the raw-score distribution. Empty
+        //       graphs fall back to the historical default so that pre-index
+        //       reads (e.g. on a brand-new workspace) behave the same as before.
+        self.centrality_k = if let Some(k) = self.centrality_k_override {
+            k
+        } else if raw_scores.is_empty() {
+            DEFAULT_CENTRALITY_K
+        } else {
+            let mut sorted: Vec<f32> = raw_scores.values().copied().collect();
+            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            let idx = ((sorted.len() - 1) as f32 * self.centrality_k_percentile).round() as usize;
+            sorted[idx.min(sorted.len() - 1)].max(CENTRALITY_K_FLOOR)
+        };
+
+        // ── 3. Materialise the per-symbol cache using the chosen `k`.
+        let k = self.centrality_k;
+        let centrality: HashMap<u64, f32> = raw_scores
+            .iter()
+            .map(|(&id, &raw)| (id, raw / (raw + k)))
             .collect();
         self.centrality_cache = Some(centrality);
 
@@ -233,7 +304,7 @@ impl CodeGraph {
             .neighbors_directed(idx, Direction::Outgoing)
             .count() as f32;
         let raw = in_degree * 2.0 + out_degree;
-        raw / (raw + 15.0)
+        raw / (raw + self.centrality_k)
     }
 
     /// Pure in-degree centrality: "how many other symbols depend on this one?"
@@ -418,5 +489,106 @@ impl CodeGraph {
 impl Default for CodeGraph {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::language::Language;
+    use crate::symbol::{EdgeKind, Symbol, SymbolKind};
+
+    fn make_symbol(name: &str, line: u32) -> Symbol {
+        Symbol::new(
+            "test.rs",
+            name,
+            SymbolKind::Function,
+            line,
+            line + 1,
+            format!("fn {}()", name),
+            None,
+            String::new(),
+            Language::Rust,
+        )
+    }
+
+    /// Empty graphs fall back to the historical default `k = 15.0`.
+    #[test]
+    fn centrality_k_empty_graph_uses_default() {
+        let mut g = CodeGraph::new();
+        g.warm_caches();
+        assert!((g.centrality_k() - DEFAULT_CENTRALITY_K).abs() < f32::EPSILON);
+    }
+
+    /// With a hand-built graph, the median raw-degree score is exactly the
+    /// chosen `k` and the median symbol scores 0.5.
+    #[test]
+    fn centrality_k_is_corpus_median() {
+        let mut g = CodeGraph::new();
+        // Five symbols. We'll wire edges so their `raw = in*2 + out` values
+        // are 0, 1, 2, 4, 8 — sorted; median is 2.
+        let ids: Vec<_> = (0..5).map(|i| make_symbol(&format!("s{}", i), i)).collect();
+        let id_vals: Vec<u64> = ids.iter().map(|s| s.id).collect();
+        for s in ids {
+            g.add_symbol(s);
+        }
+
+        // s4 ← incoming x4 → raw = 8
+        for i in 0..4 {
+            g.add_edge(id_vals[i], id_vals[4], EdgeKind::Calls);
+        }
+        // s3 ← incoming x2 → raw = 4
+        g.add_edge(id_vals[0], id_vals[3], EdgeKind::Calls);
+        g.add_edge(id_vals[1], id_vals[3], EdgeKind::Calls);
+        // s2 ← incoming x1 → raw = 2
+        g.add_edge(id_vals[0], id_vals[2], EdgeKind::Calls);
+        // s1 has only outgoing edges already counted (out: s2, s3, s4 = 3).
+        // Recompute expected raws now:
+        //   s0 (out only: s2, s3, s4, s4-attempt-dedup) — outgoing = 3, in = 0 → raw = 3
+        //   s1 (out: s3, s4) → out = 2, in = 0 → raw = 2
+        //   s2 (in:1, out:0) → raw = 2
+        //   s3 (in:2, out:0) → raw = 4
+        //   s4 (in:4, out:0) → raw = 8
+        // Sorted: [2, 2, 2, 3, 4, 8] — wait, that's six values. We only have
+        // five symbols, so the actual sorted distribution is [2, 2, 3, 4, 8],
+        // median (p50) = 3. That's what we assert.
+        g.warm_caches();
+        assert!(
+            (g.centrality_k() - 3.0).abs() < f32::EPSILON,
+            "k = {}",
+            g.centrality_k()
+        );
+
+        // Median symbol (raw = 3) must score 0.5.
+        let median_score = g.centrality_score(id_vals[0]);
+        assert!(
+            (median_score - 0.5).abs() < 1e-5,
+            "median score = {}",
+            median_score
+        );
+    }
+
+    /// Operator override pins `k` regardless of corpus distribution.
+    #[test]
+    fn centrality_k_override_pins_value() {
+        let mut g = CodeGraph::new();
+        for i in 0..3 {
+            g.add_symbol(make_symbol(&format!("s{}", i), i));
+        }
+        g.set_centrality_k_override(Some(42.0));
+        g.warm_caches();
+        assert!((g.centrality_k() - 42.0).abs() < f32::EPSILON);
+    }
+
+    /// `k` is floored to avoid division by ~0 on graphs full of leaves.
+    #[test]
+    fn centrality_k_floors_to_one() {
+        let mut g = CodeGraph::new();
+        // Three symbols, no edges → all raws are 0 → percentile = 0 → floor.
+        for i in 0..3 {
+            g.add_symbol(make_symbol(&format!("s{}", i), i));
+        }
+        g.warm_caches();
+        assert!(g.centrality_k() >= 1.0, "k = {}", g.centrality_k());
     }
 }

--- a/crates/cs-core/src/memory.rs
+++ b/crates/cs-core/src/memory.rs
@@ -155,6 +155,17 @@ pub struct IndexingConfig {
     /// restore the pre-#72 behaviour. Explicit `save_observation` calls are
     /// unaffected — they remain the agent-attested memory path.
     pub auto_observations: bool,
+
+    /// Percentile of the raw-degree distribution used to derive the centrality
+    /// smoothing constant `k` (see `CodeGraph::warm_caches`).
+    /// Set via `[ranking] centrality_k_percentile = 0.5` in `config.toml`.
+    /// Default: None (engine uses 0.5 = median).
+    pub centrality_k_percentile: Option<f32>,
+
+    /// Explicit override for the centrality smoothing constant. When set,
+    /// bypasses percentile-based derivation and pins `k` to this value.
+    /// Set via `[ranking] centrality_k = 15.0` in `config.toml`. Default: None.
+    pub centrality_k_override: Option<f32>,
 }
 
 impl IndexingConfig {
@@ -200,6 +211,19 @@ impl IndexingConfig {
             }
             if let Some(v) = obs.get("auto_observations").and_then(|v| v.as_bool()) {
                 cfg.auto_observations = v;
+            }
+        }
+        if let Some(ranking) = table.get("ranking").and_then(|v| v.as_table()) {
+            if let Some(v) = ranking
+                .get("centrality_k_percentile")
+                .and_then(|v| v.as_float())
+            {
+                cfg.centrality_k_percentile = Some(v as f32);
+            }
+            if let Some(v) = ranking.get("centrality_k").and_then(|v| v.as_float()) {
+                cfg.centrality_k_override = Some(v as f32);
+            } else if let Some(v) = ranking.get("centrality_k").and_then(|v| v.as_integer()) {
+                cfg.centrality_k_override = Some(v as f32);
             }
         }
         // CS_TRACK_MANIFEST env var overrides config.toml
@@ -249,6 +273,12 @@ impl IndexingConfig {
             }
             if ws.auto_observations {
                 cfg.auto_observations = true;
+            }
+            if ws.centrality_k_percentile.is_some() {
+                cfg.centrality_k_percentile = ws.centrality_k_percentile;
+            }
+            if ws.centrality_k_override.is_some() {
+                cfg.centrality_k_override = ws.centrality_k_override;
             }
         }
 

--- a/crates/cs-mcp/src/main.rs
+++ b/crates/cs-mcp/src/main.rs
@@ -969,6 +969,15 @@ async fn dispatch_tool(engine: &Arc<CoreEngine>, name: &str, args: &Value) -> Re
                     stats.stub_symbol_count
                 ));
             }
+            let centrality_source = if stats.centrality_k_overridden {
+                "config override".to_string()
+            } else {
+                format!("p{:.0} of corpus", stats.centrality_k_percentile * 100.0)
+            };
+            status.push_str(&format!(
+                "- Centrality k: {:.2} ({})\n",
+                stats.centrality_k, centrality_source
+            ));
             status.push_str(&format!("- Session: {}\n", stats.session_id));
             if let Some(updated_at) = &stats.manifest_updated_at {
                 let file_count = stats.manifest_file_count.unwrap_or(0);

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -321,7 +321,9 @@ rather than graph connectivity.
 
 ```
 # Code symbols:
-centrality = centrality_score(id)          # (in*2 + out) / (in*2 + out + 15)
+raw       = in_degree * 2 + out_degree
+k         = corpus_percentile(raw, p)      # default p = 0.5 (median)
+centrality = raw / (raw + k)
 final = reranked_score * (1 + centrality * 3)
 
 # Markdown symbols — centrality bypass:
@@ -330,6 +332,23 @@ final = reranked_score * 2.5
 
 `centrality_score` uses the symbol's own in+out degree (not family), appropriate for the
 general boost since it applies to all symbol kinds equally.
+
+**Why `k` is corpus-derived (issue #82):** `k` defines the degree at which a symbol scores
+0.5 — i.e., it encodes "average" for the graph. A fixed value is only correct if every
+indexed workspace has a similar degree distribution, which is not generally true (a 200-file
+script collection has nothing like the degree spread of a 50-kloc service). At index time
+`warm_caches()` collects `raw = in*2 + out` for every symbol and picks the value at the
+configured percentile (`p` = 0.5 by default), guaranteeing the median symbol scores 0.5
+regardless of corpus density. The chosen `k` is reported through `index_status` /
+`get_stats` so it's observable.
+
+Override via `[ranking]` in `.codesurgeon/config.toml`:
+
+```toml
+[ranking]
+centrality_k_percentile = 0.5   # default; set to 0.75 to favour leafier signals
+centrality_k            = 15.0  # explicit pin; bypasses percentile derivation
+```
 
 **Why markdown bypasses centrality:** Markdown symbols have no graph edges (docs are never
 imported or called), so `centrality_score` is always 0. Without the bypass, a markdown
@@ -508,7 +527,7 @@ identifies the coordinator. Requires `>= 2` owned seed types to avoid false posi
 | max_blast_radius_depth | 5 | `engine.rs` |
 | max_impact_results (per-list cap) | 100 | `engine.rs` |
 | family_in_degree k | 5 | `graph.rs` |
-| centrality_score k | 15 | `graph.rs` |
+| centrality_score k | corpus median (p50 of `in*2 + out`) | `graph.rs:warm_caches` (configurable: `[ranking] centrality_k_percentile`, `[ranking] centrality_k`) |
 | Stub score weight | × 0.3 | `ranking.rs:STUB_SCORE_WEIGHT` |
 | Trivial exception pivot filter max body lines | 3 | `ranking.rs:is_trivial_exception_pivot` |
 | Auto-observation recording (default) | off | `engine.rs:EngineConfig::auto_observations` |


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `k = 15.0` in `CodeGraph::centrality_score` with a corpus-derived value: `k = p50(in*2 + out)` by default, so the median symbol scores 0.5 regardless of corpus size or density.
- Configurable via `[ranking] centrality_k_percentile = 0.5` and `[ranking] centrality_k = N` (explicit pin).
- Surfaced through `index_status` / `get_stats` / CLI `status` so the chosen `k` is observable.
- Floored at 1.0 to avoid division-by-~0 on leaf-heavy graphs; empty graphs fall back to the historical 15.0 default.
- Adds `CS_BENCH_CENTRALITY_K` env-var override on the `token_savings` example for A/B runs against pre-#82 behaviour.
- New README section "Environment variables" documents all five env vars and fixes the stale `RUST_LOG` → `CS_LOG` reference in the troubleshooting snippet.

Closes part of #82 (issue stays open with follow-up TODOs for soak / bandit-arm wiring).

## Bench

20-query `token_savings` bench against the cs-core source tree:

| | k = 15 (pre-#82) | corpus median (#82) |
|---|---:|---:|
| Avg capsule tokens | 2770 | 2740 |
| Workspace savings | 97.9% | 97.9% |

Per-query swings up to ±668 tokens — change is doing real reranking work, but the global token envelope is unchanged.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` — all green, including 4 new unit tests in `graph::tests` for `centrality_k` derivation (empty graph, corpus median, override, floor)
- [x] `cargo run --release --example token_savings -p cs-core` — runs cleanly in both default and `CS_BENCH_CENTRALITY_K=15.0` modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)