### PR TITLE
Universally-useful subset: --version, --json CLI, anchors debug, traceback shortcut

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -30,14 +30,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Don't fail the bench job if cs-benchmark isn't published yet —
+      # the summary step skips when the script is missing. `continue-on-error`
+      # is a step-level attribute, not a `with:` input, so it must sit
+      # alongside `uses:` rather than nested under it.
       - name: Check out cs-benchmark (sibling repo with baselines + summary script)
+        continue-on-error: true
         uses: actions/checkout@v6
         with:
           repository: subsriram/cs-benchmark
           path: cs-benchmark
-          # Don't fail the bench job if cs-benchmark isn't published yet —
-          # the summary step skips when the script is missing.
-          continue-on-error: true
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Post PR comment
         if: github.event_name == 'pull_request' && steps.summary.outputs.body != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           SUMMARY_BODY: ${{ steps.summary.outputs.body }}
         with:

--- a/crates/cs-cli/src/main.rs
+++ b/crates/cs-cli/src/main.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 #[derive(Parser)]
 #[command(
     name = "codesurgeon",
-    version,
+    version = cs_core::VERSION,
     about = "Local-first codebase context engine for AI coding agents"
 )]
 struct Cli {

--- a/crates/cs-cli/src/main.rs
+++ b/crates/cs-cli/src/main.rs
@@ -57,6 +57,11 @@ enum Commands {
         /// to read from stdin.
         #[arg(long)]
         context: Option<String>,
+        /// Emit the structured capsule as JSON (pivots, skeletons,
+        /// memories, stats) instead of the markdown rendering. Useful
+        /// for tooling that needs to inspect retrieval programmatically.
+        #[arg(long)]
+        json: bool,
     },
 
     /// Show current configuration
@@ -65,8 +70,31 @@ enum Commands {
     /// Show skeleton (signatures only) for a file
     Skeleton { file_path: String },
 
+    /// Extract symbol-name anchors from a query (debug). Lets tooling
+    /// see what `run_pipeline`'s anchor extractor would resolve from a
+    /// given problem statement before going through full retrieval.
+    Anchors {
+        /// Free-form query text. Same format as `context` accepts (`task` +
+        /// optional `--context`).
+        query: String,
+        /// Optional raw-text blob (full problem statement / traceback). Use
+        /// @path/to/file or - for stdin, same conventions as `context`.
+        #[arg(long)]
+        context: Option<String>,
+        /// Emit JSON instead of plain text.
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Show what would break if a symbol changed
-    Impact { symbol_fqn: String },
+    Impact {
+        symbol_fqn: String,
+        /// Emit the structured ImpactResult as JSON (direct + transitive
+        /// dependents, truncation counts, total_affected) instead of the
+        /// human-readable rendering.
+        #[arg(long)]
+        json: bool,
+    },
 
     /// Trace a logic path between two symbols
     Flow { from: String, to: String },
@@ -119,7 +147,11 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Log to stderr so debug output doesn't pollute the stdout JSON
+    // emitted by `--json` modes. Mirrors `codesurgeon-mcp`, where stdout
+    // is the JSON-RPC channel.
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(std::env::var("CS_LOG").unwrap_or_else(|_| "warn".to_string()))
         .init();
 
@@ -168,6 +200,7 @@ async fn main() -> Result<()> {
             language,
             file_hint,
             context,
+            json,
         } => {
             // Resolve @path / - / literal into a plain String, matching the
             // existing `diff` subcommand's ergonomics.
@@ -182,14 +215,25 @@ async fn main() -> Result<()> {
                 Some(s) => Some(s.to_string()),
                 None => None,
             };
-            let result = engine.run_pipeline_with_context(
-                &task,
-                context_resolved.as_deref(),
-                Some(budget),
-                language.as_deref(),
-                file_hint.as_deref(),
-            )?;
-            println!("{}", result);
+            if json {
+                let capsule = engine.run_pipeline_capsule_with_context(
+                    &task,
+                    context_resolved.as_deref(),
+                    Some(budget),
+                    language.as_deref(),
+                    file_hint.as_deref(),
+                )?;
+                println!("{}", serde_json::to_string_pretty(&capsule)?);
+            } else {
+                let result = engine.run_pipeline_with_context(
+                    &task,
+                    context_resolved.as_deref(),
+                    Some(budget),
+                    language.as_deref(),
+                    file_hint.as_deref(),
+                )?;
+                println!("{}", result);
+            }
         }
 
         Commands::Config => {
@@ -262,8 +306,56 @@ async fn main() -> Result<()> {
             }
         }
 
-        Commands::Impact { symbol_fqn } => {
+        Commands::Anchors {
+            query,
+            context,
+            json,
+        } => {
+            let context_resolved: Option<String> = match context.as_deref() {
+                Some("-") => {
+                    use std::io::Read;
+                    let mut buf = String::new();
+                    std::io::stdin().read_to_string(&mut buf)?;
+                    Some(buf)
+                }
+                Some(s) if s.starts_with('@') => Some(std::fs::read_to_string(&s[1..])?),
+                Some(s) => Some(s.to_string()),
+                None => None,
+            };
+            // Anchor extraction reads `task` + `\n` + `context`, mirroring
+            // run_pipeline_with_context's anchor_source.
+            let anchor_source = match context_resolved.as_deref() {
+                Some(c) if !c.is_empty() => format!("{}\n{}", query, c),
+                _ => query.clone(),
+            };
+            let anchors = cs_core::anchors::extract(&anchor_source);
+            if json {
+                println!("{}", serde_json::to_string_pretty(&anchors)?);
+            } else {
+                println!("symbol_names ({}):", anchors.symbol_names.len());
+                for n in &anchors.symbol_names {
+                    let dotted_tag = if anchors.from_dotted_call.contains(n) {
+                        " (dotted)"
+                    } else {
+                        ""
+                    };
+                    println!("  {}{}", n, dotted_tag);
+                }
+                if !anchors.module_paths.is_empty() {
+                    println!("\nmodule_paths ({}):", anchors.module_paths.len());
+                    for m in &anchors.module_paths {
+                        println!("  {}", m);
+                    }
+                }
+            }
+        }
+
+        Commands::Impact { symbol_fqn, json } => {
             let result = engine.get_impact_graph(&symbol_fqn, None, None, true)?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&result)?);
+                return Ok(());
+            }
             println!("Impact graph for: {}", result.target_fqn);
             println!("Total affected: {}\n", result.total_affected);
 

--- a/crates/cs-cli/tests/cli.rs
+++ b/crates/cs-cli/tests/cli.rs
@@ -446,6 +446,103 @@ fn context_without_task_exits_nonzero() {
     );
 }
 
+/// `context --json` must emit valid serde-parseable JSON on stdout.
+/// This pins the contract that `--json` doesn't include trailing
+/// markdown / status text and stays a clean JSON document.
+#[test]
+fn context_json_emits_valid_json() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("m.py"), "def foo():\n    return 1\n").unwrap();
+    // index first so the capsule has something to surface
+    let idx = run(&dir, &["index"]);
+    assert!(idx.status.success(), "index failed: {}", stderr(&idx));
+
+    let out = run(&dir, &["context", "fix foo", "--json"]);
+    assert!(
+        out.status.success(),
+        "context --json failed: {}",
+        stderr(&out)
+    );
+    let s = stdout(&out);
+    let _: serde_json::Value = serde_json::from_str(&s)
+        .unwrap_or_else(|e| panic!("stdout not JSON: {e}\n--- stdout ---\n{s}"));
+}
+
+/// `impact --json` on a missing symbol must still emit valid JSON
+/// (the capsule shape is well-defined for the empty case).
+#[test]
+fn impact_json_emits_valid_json() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("m.py"), "def foo():\n    return 1\n").unwrap();
+    let idx = run(&dir, &["index"]);
+    assert!(idx.status.success(), "index failed: {}", stderr(&idx));
+
+    let out = run(&dir, &["impact", "m.py::foo", "--json"]);
+    assert!(
+        out.status.success(),
+        "impact --json failed: {}",
+        stderr(&out)
+    );
+    let s = stdout(&out);
+    let _: serde_json::Value = serde_json::from_str(&s)
+        .unwrap_or_else(|e| panic!("stdout not JSON: {e}\n--- stdout ---\n{s}"));
+}
+
+/// `anchors --json` must emit a valid JSON document, even with no symbols
+/// extracted (the empty-anchors object is still well-formed).
+#[test]
+fn anchors_json_emits_valid_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = run(&dir, &["anchors", "fix parse_latex bug"]);
+    // Without --json this is the human-readable view; smoke-check it works.
+    assert!(out.status.success(), "anchors failed: {}", stderr(&out));
+
+    let out = run(&dir, &["anchors", "fix parse_latex bug", "--json"]);
+    assert!(
+        out.status.success(),
+        "anchors --json failed: {}",
+        stderr(&out)
+    );
+    let s = stdout(&out);
+    let _: serde_json::Value = serde_json::from_str(&s)
+        .unwrap_or_else(|e| panic!("stdout not JSON: {e}\n--- stdout ---\n{s}"));
+}
+
+/// With `CS_LOG=debug`, log output must go to stderr — never stdout.
+/// Critical for `--json` modes: any log line on stdout corrupts the JSON
+/// document. Also confirms that debug logging is actually wired up.
+#[test]
+fn logs_go_to_stderr_not_stdout_under_json() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("m.py"), "def foo():\n    return 1\n").unwrap();
+    let idx = run(&dir, &["index"]);
+    assert!(idx.status.success(), "index failed: {}", stderr(&idx));
+
+    let out = Command::new(BIN)
+        .env("CS_WORKSPACE", dir.path())
+        .env("CS_LOG", "debug")
+        .args(["context", "fix foo", "--json"])
+        .output()
+        .expect("failed to spawn codesurgeon");
+    assert!(
+        out.status.success(),
+        "context --json under CS_LOG=debug failed: {}",
+        stderr(&out)
+    );
+    let s_out = stdout(&out);
+    let s_err = stderr(&out);
+    // stdout must still be a single JSON document — no log noise.
+    let _: serde_json::Value = serde_json::from_str(&s_out).unwrap_or_else(|e| {
+        panic!("stdout not JSON under debug logging: {e}\n--- stdout ---\n{s_out}")
+    });
+    // stderr must contain *something* — proves the subscriber is wired and writing there.
+    // We don't pin a specific message because the exact debug lines may evolve.
+    assert!(
+        !s_err.trim().is_empty(),
+        "expected some debug output on stderr with CS_LOG=debug"
+    );
+}
+
 // ── config ───────────────────────────────────────────────────────────────────
 
 /// `config` on workspace without config file must exit zero and show defaults message.

--- a/crates/cs-core/Cargo.toml
+++ b/crates/cs-core/Cargo.toml
@@ -85,6 +85,9 @@ default    = []
 embeddings = ["dep:fastembed", "dep:memmap2"]
 metal      = ["embeddings", "fastembed/accelerate"]
 
+[build-dependencies]
+chrono = { version = "0.4" }
+
 [dev-dependencies]
 tempfile = "3"
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/cs-core/build.rs
+++ b/crates/cs-core/build.rs
@@ -9,14 +9,19 @@
 //! has uncommitted changes — important for benchmark reproducibility,
 //! since a `+dirty` build doesn't correspond to any merged commit.
 
+use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
-    // Re-run when HEAD moves (commit, branch switch). The .git path is
-    // resolved relative to the workspace root; cs-core lives at
-    // `crates/cs-core/` so we go up two levels.
-    println!("cargo:rerun-if-changed=../../.git/HEAD");
-    println!("cargo:rerun-if-changed=../../.git/index");
+    // Re-run when HEAD moves (commit, branch switch). Resolve the git dir
+    // via `git rev-parse --git-dir` rather than hardcoding `../../.git/HEAD`
+    // — in a worktree the top-level `.git` is a *file* pointing to
+    // `<repo>/.git/worktrees/<name>`, so the hardcoded path doesn't exist
+    // and the rerun trigger silently fails.
+    if let Some(git_dir) = git_dir() {
+        println!("cargo:rerun-if-changed={}/HEAD", git_dir.display());
+        println!("cargo:rerun-if-changed={}/index", git_dir.display());
+    }
 
     let sha = git_short_sha().unwrap_or_else(|| "unknown".to_string());
     let dirty = git_is_dirty().unwrap_or(false);
@@ -26,6 +31,21 @@ fn main() {
 
     println!("cargo:rustc-env=CS_GIT_SHA={}", sha_full);
     println!("cargo:rustc-env=CS_BUILD_TIME={}", build_time);
+}
+
+fn git_dir() -> Option<PathBuf> {
+    let out = Command::new("git")
+        .args(["rev-parse", "--git-dir"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if path.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(path))
 }
 
 fn git_short_sha() -> Option<String> {

--- a/crates/cs-core/build.rs
+++ b/crates/cs-core/build.rs
@@ -1,0 +1,51 @@
+//! Capture git SHA + build timestamp into compile-time env vars so both
+//! `codesurgeon` and `codesurgeon-mcp` can report which build is running.
+//!
+//! Exposed as `cs_core::GIT_SHA` / `cs_core::BUILD_TIME` / `cs_core::VERSION`
+//! (see `src/lib.rs`). The version string is what `--version` prints.
+//!
+//! Falls back to `unknown` for the SHA when not in a git checkout (e.g.
+//! crate published to crates.io). Marks `+dirty` when the working tree
+//! has uncommitted changes — important for benchmark reproducibility,
+//! since a `+dirty` build doesn't correspond to any merged commit.
+
+use std::process::Command;
+
+fn main() {
+    // Re-run when HEAD moves (commit, branch switch). The .git path is
+    // resolved relative to the workspace root; cs-core lives at
+    // `crates/cs-core/` so we go up two levels.
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/index");
+
+    let sha = git_short_sha().unwrap_or_else(|| "unknown".to_string());
+    let dirty = git_is_dirty().unwrap_or(false);
+    let sha_full = if dirty { format!("{}+dirty", sha) } else { sha };
+
+    let build_time = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+
+    println!("cargo:rustc-env=CS_GIT_SHA={}", sha_full);
+    println!("cargo:rustc-env=CS_BUILD_TIME={}", build_time);
+}
+
+fn git_short_sha() -> Option<String> {
+    let out = Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+fn git_is_dirty() -> Option<bool> {
+    let out = Command::new("git")
+        .args(["status", "--porcelain", "--untracked-files=no"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(!out.stdout.is_empty())
+}

--- a/crates/cs-core/src/anchors.rs
+++ b/crates/cs-core/src/anchors.rs
@@ -190,7 +190,7 @@ fn traceback_frame_re() -> &'static Regex {
 }
 
 /// Extracted anchors, in order of discovery.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Anchors {
     /// Symbol names to try looking up exactly (deduplicated, in order).
     pub symbol_names: Vec<String>,

--- a/crates/cs-core/src/anchors.rs
+++ b/crates/cs-core/src/anchors.rs
@@ -202,6 +202,25 @@ pub struct Anchors {
     /// class methods (2+ `::`), since a dotted call is almost always a
     /// module-level function, not a method.
     pub from_dotted_call: HashSet<String>,
+    /// Python traceback frames as `(file_path, function_name)` pairs.
+    /// Distinct from `symbol_names` because tracebacks carry **both** the
+    /// file path and the function name — that's enough to do a precise
+    /// graph lookup without going through BM25/RRF. Used by the
+    /// traceback shortcut in `engine.rs::traceback_candidates`: every
+    /// frame is pinned as a high-confidence pivot candidate, bypassing
+    /// the walk-direction question.
+    pub traceback_frames: Vec<TracebackFrame>,
+}
+
+/// One frame of a Python traceback, captured by `traceback_frame_re`.
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+pub struct TracebackFrame {
+    /// File path as it appears in the traceback — relative or absolute.
+    /// The graph lookup uses suffix matching to tolerate path differences.
+    pub file_path: String,
+    /// Function or method name. Synthetic names (`<module>`, `<genexpr>`,
+    /// `<listcomp>`) are filtered out at extraction time.
+    pub function_name: String,
 }
 
 /// Extract anchor candidates from a free-form query.
@@ -285,6 +304,7 @@ pub fn extract(query: &str) -> Anchors {
     //    Inserted after imports and before prose so traceback identifiers
     //    get rank priority over generic prose tokens.
     for cap in traceback_frame_re().captures_iter(query) {
+        let file_path = cap.get(1).map(|m| m.as_str().to_string());
         if let Some(func) = cap.get(2) {
             let name = func.as_str();
             if name.starts_with('<') || name.len() < 3 {
@@ -292,6 +312,15 @@ pub fn extract(query: &str) -> Anchors {
             }
             if STOP_WORDS.contains(&name.to_lowercase().as_str()) {
                 continue;
+            }
+            // Record the (file, function) pair separately so the engine
+            // can use it as a direct pivot candidate via the traceback
+            // shortcut (engine.rs::traceback_candidates).
+            if let Some(fp) = file_path {
+                out.traceback_frames.push(TracebackFrame {
+                    file_path: fp,
+                    function_name: name.to_string(),
+                });
             }
             // Dotted frame name (e.g. `ClassName.method_name`) — push both
             // the full chain and the tail so the resolver has options.

--- a/crates/cs-core/src/anchors.rs
+++ b/crates/cs-core/src/anchors.rs
@@ -190,7 +190,7 @@ fn traceback_frame_re() -> &'static Regex {
 }
 
 /// Extracted anchors, in order of discovery.
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct Anchors {
     /// Symbol names to try looking up exactly (deduplicated, in order).
     pub symbol_names: Vec<String>,
@@ -213,7 +213,7 @@ pub struct Anchors {
 }
 
 /// One frame of a Python traceback, captured by `traceback_frame_re`.
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct TracebackFrame {
     /// File path as it appears in the traceback — relative or absolute.
     /// The graph lookup uses suffix matching to tolerate path differences.

--- a/crates/cs-core/src/db.rs
+++ b/crates/cs-core/src/db.rs
@@ -111,6 +111,44 @@ impl Database {
         let _ = self
             .conn
             .execute("ALTER TABLE symbols ADD COLUMN resolved_type TEXT", []);
+        // `leaf_name` — last `::`-segment of the qualified `name`. Class
+        // methods are stored with `name = "Class::method"` (the indexer
+        // convention), so a direct lookup like `WHERE name = "method"`
+        // misses them. The leaf column lets `symbols_by_leaf_name` find
+        // both top-level functions (where leaf == name) and class methods
+        // (where leaf is the trailing segment) with a single indexed
+        // lookup. Used by `anchor_candidates` and `traceback_candidates`
+        // so anchor extraction and Python traceback frame resolution
+        // catch class methods.
+        let _ = self
+            .conn
+            .execute("ALTER TABLE symbols ADD COLUMN leaf_name TEXT", []);
+        let _ = self.conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_symbols_leaf_name ON symbols(leaf_name);",
+        );
+        // Populate leaf_name for rows that pre-date this migration.
+        // SQLite has no native rsplit, so compute in Rust and write back.
+        // One-shot at startup; idempotent because we only touch NULL rows.
+        let pending: Vec<(i64, String)> = {
+            let mut stmt = self
+                .conn
+                .prepare("SELECT id, name FROM symbols WHERE leaf_name IS NULL")?;
+            let rows = stmt.query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?)))?;
+            rows.flatten().collect()
+        };
+        if !pending.is_empty() {
+            self.conn.execute_batch("BEGIN")?;
+            {
+                let mut update = self
+                    .conn
+                    .prepare("UPDATE symbols SET leaf_name = ?1 WHERE id = ?2")?;
+                for (id, name) in &pending {
+                    let leaf = leaf_of_name(name);
+                    let _ = update.execute(params![leaf, id]);
+                }
+            }
+            self.conn.execute_batch("COMMIT")?;
+        }
         let _ = self.conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS macro_expand_cache \
              (file_path TEXT PRIMARY KEY, source_hash TEXT NOT NULL);",
@@ -175,8 +213,8 @@ impl Database {
             r#"INSERT OR REPLACE INTO symbols
                (id, fqn, name, kind, file_path, start_line, end_line,
                 signature, docstring, body, language, content_hash, is_stub, source,
-                resolved_type)
-               VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15)"#,
+                resolved_type, leaf_name)
+               VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16)"#,
             params![
                 sym.id as i64,
                 sym.fqn,
@@ -193,6 +231,7 @@ impl Database {
                 sym.is_stub as i64,
                 sym.source,
                 sym.resolved_type,
+                leaf_of_name(&sym.name),
             ],
         )?;
         // Keep FTS in sync
@@ -255,6 +294,25 @@ impl Database {
             .prepare_cached("SELECT id FROM symbols WHERE name = ?1 LIMIT ?2")?;
         let ids = stmt
             .query_map(params![name, limit as i64], |row| row.get::<_, i64>(0))?
+            .filter_map(|r| r.ok())
+            .map(|id| id as u64)
+            .collect();
+        Ok(ids)
+    }
+
+    /// Match by the *leaf* of the qualified `name` — the segment after the
+    /// last `::`. Class methods are indexed with `name = "Class::method"`
+    /// so `symbols_by_exact_name("method")` misses them; this lookup
+    /// catches both top-level functions (where leaf == name) and class
+    /// methods (where leaf is the trailing `::`-segment). Used by
+    /// `anchor_candidates` and `traceback_candidates` so anchor extraction
+    /// and Python traceback frame resolution catch class methods.
+    pub fn symbols_by_leaf_name(&self, leaf: &str, limit: usize) -> Result<Vec<u64>> {
+        let mut stmt = self
+            .conn
+            .prepare_cached("SELECT id FROM symbols WHERE leaf_name = ?1 LIMIT ?2")?;
+        let ids = stmt
+            .query_map(params![leaf, limit as i64], |row| row.get::<_, i64>(0))?
             .filter_map(|r| r.ok())
             .map(|id| id as u64)
             .collect();
@@ -1036,6 +1094,16 @@ impl Language {
     }
 }
 
+/// Compute the leaf segment of a qualified `name`. Symbols stored with
+/// `name = "Class::method"` (the indexer convention for class methods)
+/// resolve to leaf `"method"`. Symbols stored with `name = "function"`
+/// (top-level functions) resolve to themselves. Used by both
+/// `symbols_by_leaf_name` and the `leaf_name` column populated at
+/// `upsert_symbol` time.
+pub fn leaf_of_name(name: &str) -> &str {
+    name.rsplit("::").next().unwrap_or(name)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1044,6 +1112,108 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let db = Database::open(&dir.path().join("test.db")).unwrap();
         (db, dir)
+    }
+
+    #[test]
+    fn leaf_of_name_extracts_trailing_segment() {
+        // Top-level functions: leaf == name.
+        assert_eq!(leaf_of_name("hist"), "hist");
+        // Class methods: stored as `Class::method`, leaf is the method name.
+        assert_eq!(leaf_of_name("Axes::hist"), "hist");
+        // Nested: deepest segment wins.
+        assert_eq!(leaf_of_name("Outer::Inner::method"), "method");
+        // Defensive: empty name returns empty.
+        assert_eq!(leaf_of_name(""), "");
+    }
+
+    #[test]
+    fn symbols_by_leaf_name_finds_class_methods() {
+        // `Axes::hist` is stored with `name = "Axes::hist"` so
+        // `WHERE name = "hist"` (the existing exact-name lookup) misses
+        // it. The leaf-name lookup must catch both top-level functions
+        // (where leaf == name) and class methods (where leaf is the
+        // trailing `::`-segment).
+        let (db, _dir) = open_temp_db();
+        let top_level = Symbol::new(
+            "lib/foo.py",
+            "hist",
+            SymbolKind::Function,
+            1,
+            10,
+            "def hist(): ...".to_string(),
+            None,
+            "def hist(): pass".to_string(),
+            Language::Python,
+        );
+        let method = Symbol::new(
+            "lib/bar.py",
+            "Axes::hist",
+            SymbolKind::Method,
+            5,
+            20,
+            "def hist(self): ...".to_string(),
+            None,
+            "def hist(self): pass".to_string(),
+            Language::Python,
+        );
+        db.upsert_symbol(&top_level).unwrap();
+        db.upsert_symbol(&method).unwrap();
+
+        // Old behaviour: `name`-only lookup misses the method.
+        let by_name = db.symbols_by_exact_name("hist", 10).unwrap();
+        assert_eq!(by_name.len(), 1, "exact-name should miss Class::method");
+        assert_eq!(by_name[0], top_level.id);
+
+        // New behaviour: leaf-name lookup catches both.
+        let by_leaf = db.symbols_by_leaf_name("hist", 10).unwrap();
+        assert_eq!(
+            by_leaf.len(),
+            2,
+            "leaf-name should catch top-level + method"
+        );
+        assert!(by_leaf.contains(&top_level.id));
+        assert!(by_leaf.contains(&method.id));
+    }
+
+    #[test]
+    fn leaf_name_migration_backfills_existing_rows() {
+        // Existing `.codesurgeon` workspaces have rows with `leaf_name =
+        // NULL` from before the column was added. The schema setup runs
+        // a one-shot UPDATE to populate them. Verify by simulating an
+        // "old" DB: open once to create the schema, null out the
+        // leaf_name column for an existing row, close, reopen — the
+        // migration should re-populate.
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        {
+            let db = Database::open(&db_path).unwrap();
+            let method = Symbol::new(
+                "lib/bar.py",
+                "Axes::hist",
+                SymbolKind::Method,
+                5,
+                20,
+                "def hist(self): ...".to_string(),
+                None,
+                "def hist(self): pass".to_string(),
+                Language::Python,
+            );
+            db.upsert_symbol(&method).unwrap();
+        }
+        // Simulate the "pre-migration" state by nulling the leaf_name.
+        {
+            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            conn.execute("UPDATE symbols SET leaf_name = NULL", [])
+                .unwrap();
+        }
+        // Reopen — `create_schema` should backfill leaf_name.
+        let db = Database::open(&db_path).unwrap();
+        let by_leaf = db.symbols_by_leaf_name("hist", 10).unwrap();
+        assert_eq!(
+            by_leaf.len(),
+            1,
+            "migration should have backfilled leaf_name = 'hist' for the method"
+        );
     }
 
     /// `log_query` must not error, and `query_log_rows` must return the inserted row.

--- a/crates/cs-core/src/engine.rs
+++ b/crates/cs-core/src/engine.rs
@@ -24,7 +24,7 @@ use crate::ranking::{
     ANCHOR_ROWS_PER_NAME, ANCHOR_RRF_K, CENTRALITY_BOOST, GRAPH_CANDIDATES,
     MARKDOWN_CENTRALITY_BYPASS, REVERSE_EXPAND_CANDIDATES, REVERSE_EXPAND_FAN_OUT,
     REVERSE_EXPAND_MAX_DEPTH, REVERSE_EXPAND_RRF_K, REVERSE_EXPAND_SEED_MAX_CALLERS, RRF_K,
-    STUB_SCORE_WEIGHT,
+    STUB_SCORE_WEIGHT, TRACEBACK_RRF_K,
 };
 #[cfg(feature = "embeddings")]
 use crate::ranking::{ANN_CANDIDATES, BM25_BLEND_WEIGHT, SEMANTIC_BLEND_WEIGHT};
@@ -2269,6 +2269,53 @@ impl CoreEngine {
     ///
     /// Returns `(symbol_id, 1.0)` pairs in extraction order. RRF fusion
     /// handles rank-based blending with BM25 / graph / ANN.
+    /// Resolve Python traceback frames in `query` to symbol IDs.
+    ///
+    /// Each frame carries `(file_path, function_name)` — enough for a
+    /// precision-first lookup that doesn't go through BM25/embeddings.
+    /// The traceback IS the call chain; every frame is a member of the
+    /// bug's code path.
+    ///
+    /// Returns `(symbol_id, 1.0)` pairs in frame order (most-recent call
+    /// first, the typical Python traceback convention). RRF fusion at
+    /// `TRACEBACK_RRF_K` ensures rank-1 frames dominate any single
+    /// BM25/ANN hit.
+    ///
+    /// File-path matching is suffix-based: a traceback frame
+    /// `astropy/io/registry.py` matches an indexed symbol whose
+    /// `file_path` ends with that string. This tolerates absolute paths
+    /// in tracebacks vs. workspace-relative paths in the index.
+    fn traceback_candidates(&self, query: &str) -> Vec<(u64, f32)> {
+        let anchors = crate::anchors::extract(query);
+        if anchors.traceback_frames.is_empty() {
+            return Vec::new();
+        }
+        let graph = self.graph.read();
+        let mut out: Vec<(u64, f32)> = Vec::new();
+        let mut seen: HashSet<u64> = HashSet::new();
+        for frame in &anchors.traceback_frames {
+            // Function name may be dotted (`Class.method`); resolver-side
+            // we use the last segment for symbol-name matching.
+            let func = frame
+                .function_name
+                .rsplit('.')
+                .next()
+                .unwrap_or(&frame.function_name);
+            for sym in graph.all_symbols() {
+                if sym.name != func {
+                    continue;
+                }
+                if !sym.file_path.ends_with(&frame.file_path) {
+                    continue;
+                }
+                if seen.insert(sym.id) {
+                    out.push((sym.id, 1.0));
+                }
+            }
+        }
+        out
+    }
+
     fn anchor_candidates(&self, query: &str, limit: usize) -> (Vec<(u64, f32)>, AnchorStats) {
         let anchors = crate::anchors::extract(query);
         if anchors.symbol_names.is_empty() {
@@ -2664,11 +2711,26 @@ impl CoreEngine {
             Vec::new()
         };
 
+        // Traceback shortcut: when `--context` contains a Python traceback,
+        // every frame's `(file, function)` resolves to a high-confidence
+        // pivot candidate. The traceback IS the call chain; we feed its
+        // frames into RRF at the most aggressive `k` (`TRACEBACK_RRF_K`)
+        // so rank-1 frames dominate any single BM25/ANN hit. Empty when
+        // no Python traceback is present in the query/context.
+        let traceback_results = self.traceback_candidates(&anchor_source);
+        if !traceback_results.is_empty() {
+            tracing::debug!(
+                "traceback shortcut: {} frame symbols resolved",
+                traceback_results.len()
+            );
+        }
+
         // ANN semantic retrieval + RRF fusion across all sources.
         // The anchor list fuses with a smaller `k` (ANCHOR_RRF_K) so that a
         // rank-1 precision-first anchor hit outweighs a rank-1 BM25 hit that
-        // lost the target to body-field noise. Reverse-expansion sits between
-        // anchors and the default retrievers (`REVERSE_EXPAND_RRF_K`).
+        // lost the target to body-field noise. Traceback frames sit at the
+        // most aggressive `k` (TRACEBACK_RRF_K). Reverse-expansion sits
+        // between anchors and the default retrievers (`REVERSE_EXPAND_RRF_K`).
         #[cfg(feature = "embeddings")]
         let mut search_results = {
             let ann_results = self.ann_candidates(query, ANN_CANDIDATES);
@@ -2677,6 +2739,7 @@ impl CoreEngine {
                 (&graph_results, RRF_K),
                 (&ann_results, RRF_K),
                 (&anchor_results, ANCHOR_RRF_K),
+                (&traceback_results, TRACEBACK_RRF_K),
                 (&reverse_results, REVERSE_EXPAND_RRF_K),
             ])
         };
@@ -2685,6 +2748,7 @@ impl CoreEngine {
             (&bm25_results, RRF_K),
             (&graph_results, RRF_K),
             (&anchor_results, ANCHOR_RRF_K),
+            (&traceback_results, TRACEBACK_RRF_K),
             (&reverse_results, REVERSE_EXPAND_RRF_K),
         ]);
 

--- a/crates/cs-core/src/engine.rs
+++ b/crates/cs-core/src/engine.rs
@@ -24,7 +24,7 @@ use crate::ranking::{
     ANCHOR_ROWS_PER_NAME, ANCHOR_RRF_K, CENTRALITY_BOOST, GRAPH_CANDIDATES,
     MARKDOWN_CENTRALITY_BYPASS, REVERSE_EXPAND_CANDIDATES, REVERSE_EXPAND_FAN_OUT,
     REVERSE_EXPAND_MAX_DEPTH, REVERSE_EXPAND_RRF_K, REVERSE_EXPAND_SEED_MAX_CALLERS, RRF_K,
-    STUB_SCORE_WEIGHT, TRACEBACK_RRF_K,
+    STUB_SCORE_WEIGHT, TRACEBACK_LEAF_PROBE, TRACEBACK_RRF_K,
 };
 #[cfg(feature = "embeddings")]
 use crate::ranking::{ANN_CANDIDATES, BM25_BLEND_WEIGHT, SEMANTIC_BLEND_WEIGHT};
@@ -2259,16 +2259,6 @@ impl CoreEngine {
 
     // ── Internal ──────────────────────────────────────────────────────────────
 
-    /// Stage 1: explicit symbol-name anchors.
-    ///
-    /// Extracts identifier-shaped tokens from the query (prose, imports, and
-    /// code-block API calls) and looks them up by exact name in the symbol
-    /// table. Unlike BM25, this is a precision-first signal: if a task names
-    /// `parse_latex` or calls `xr.where(...)`, we want that symbol promoted
-    /// directly regardless of how many other files mention the word.
-    ///
-    /// Returns `(symbol_id, 1.0)` pairs in extraction order. RRF fusion
-    /// handles rank-based blending with BM25 / graph / ANN.
     /// Resolve Python traceback frames in `query` to symbol IDs.
     ///
     /// Each frame carries `(file_path, function_name)` — enough for a
@@ -2285,11 +2275,11 @@ impl CoreEngine {
     /// `astropy/io/registry.py` matches an indexed symbol whose
     /// `file_path` ends with that string. This tolerates absolute paths
     /// in tracebacks vs. workspace-relative paths in the index.
-    fn traceback_candidates(&self, query: &str) -> Vec<(u64, f32)> {
-        let anchors = crate::anchors::extract(query);
+    fn traceback_candidates(&self, anchors: &crate::anchors::Anchors) -> Vec<(u64, f32)> {
         if anchors.traceback_frames.is_empty() {
             return Vec::new();
         }
+        let db = self.db.lock();
         let graph = self.graph.read();
         let mut out: Vec<(u64, f32)> = Vec::new();
         let mut seen: HashSet<u64> = HashSet::new();
@@ -2301,15 +2291,20 @@ impl CoreEngine {
                 .rsplit('.')
                 .next()
                 .unwrap_or(&frame.function_name);
-            // Match on leaf-of-name (last `::`-segment) so class methods
-            // stored with `name = "Class::method"` resolve when the
-            // traceback frame says `in method`. Top-level functions
-            // (where leaf == name) also match — leaf is a superset of name
-            // for the comparison purposes.
-            for sym in graph.all_symbols() {
-                if crate::db::leaf_of_name(&sym.name) != func {
+            // Use the `leaf_name` index to fetch only symbols whose leaf
+            // matches `func` — avoids the O(|graph|) walk per frame.
+            // A reasonable cap: a single leaf-name almost never has more
+            // than a handful of definitions across a workspace; if it does
+            // (e.g. `__init__`), we only care about ones in this frame's
+            // file, which the suffix filter below selects.
+            let ids = match db.symbols_by_leaf_name(func, TRACEBACK_LEAF_PROBE) {
+                Ok(ids) => ids,
+                Err(_) => continue,
+            };
+            for id in ids {
+                let Some(sym) = graph.get_symbol(id) else {
                     continue;
-                }
+                };
                 if !sym.file_path.ends_with(&frame.file_path) {
                     continue;
                 }
@@ -2321,8 +2316,21 @@ impl CoreEngine {
         out
     }
 
-    fn anchor_candidates(&self, query: &str, limit: usize) -> (Vec<(u64, f32)>, AnchorStats) {
-        let anchors = crate::anchors::extract(query);
+    /// Stage 1: explicit symbol-name anchors.
+    ///
+    /// Extracts identifier-shaped tokens from the query (prose, imports, and
+    /// code-block API calls) and looks them up by exact name in the symbol
+    /// table. Unlike BM25, this is a precision-first signal: if a task names
+    /// `parse_latex` or calls `xr.where(...)`, we want that symbol promoted
+    /// directly regardless of how many other files mention the word.
+    ///
+    /// Returns `(symbol_id, 1.0)` pairs in extraction order. RRF fusion
+    /// handles rank-based blending with BM25 / graph / ANN.
+    fn anchor_candidates(
+        &self,
+        anchors: &crate::anchors::Anchors,
+        limit: usize,
+    ) -> (Vec<(u64, f32)>, AnchorStats) {
         if anchors.symbol_names.is_empty() {
             return (vec![], AnchorStats::default());
         }
@@ -2613,7 +2621,9 @@ impl CoreEngine {
             Some(ctx) if !ctx.is_empty() => format!("{query}\n{ctx}"),
             _ => query.to_string(),
         };
-        let (anchor_results, astats) = self.anchor_candidates(&anchor_source, ANCHOR_CANDIDATES);
+        // Extract once, reuse for both anchor_candidates and traceback_candidates.
+        let extracted = crate::anchors::extract(&anchor_source);
+        let (anchor_results, astats) = self.anchor_candidates(&extracted, ANCHOR_CANDIDATES);
         tracing::debug!(
             "anchor stats: {:?} (context bytes: {})",
             astats,
@@ -2727,7 +2737,7 @@ impl CoreEngine {
         // frames into RRF at the most aggressive `k` (`TRACEBACK_RRF_K`)
         // so rank-1 frames dominate any single BM25/ANN hit. Empty when
         // no Python traceback is present in the query/context.
-        let traceback_results = self.traceback_candidates(&anchor_source);
+        let traceback_results = self.traceback_candidates(&extracted);
         if !traceback_results.is_empty() {
             tracing::debug!(
                 "traceback shortcut: {} frame symbols resolved",

--- a/crates/cs-core/src/engine.rs
+++ b/crates/cs-core/src/engine.rs
@@ -2301,8 +2301,13 @@ impl CoreEngine {
                 .rsplit('.')
                 .next()
                 .unwrap_or(&frame.function_name);
+            // Match on leaf-of-name (last `::`-segment) so class methods
+            // stored with `name = "Class::method"` resolve when the
+            // traceback frame says `in method`. Top-level functions
+            // (where leaf == name) also match — leaf is a superset of name
+            // for the comparison purposes.
             for sym in graph.all_symbols() {
-                if sym.name != func {
+                if crate::db::leaf_of_name(&sym.name) != func {
                     continue;
                 }
                 if !sym.file_path.ends_with(&frame.file_path) {
@@ -2349,7 +2354,12 @@ impl CoreEngine {
             } else {
                 ANCHOR_ROWS_PER_NAME
             };
-            let exact_ids = match db.symbols_by_exact_name(lookup, fetch) {
+            // Match by `leaf_name` so class methods (stored with
+            // `name = "Class::method"`) are reachable via their bare
+            // `method` lookup. The `prefer_module` sort still applies —
+            // it prefers fewer-`::` fqns, so module-level functions
+            // sort ahead of methods within the truncated top-K.
+            let exact_ids = match db.symbols_by_leaf_name(lookup, fetch) {
                 Ok(mut ids) => {
                     if prefer_module {
                         ids.sort_by_key(|id| {

--- a/crates/cs-core/src/engine.rs
+++ b/crates/cs-core/src/engine.rs
@@ -1331,6 +1331,37 @@ impl CoreEngine {
         language: Option<&str>,
         file_hint: Option<&str>,
     ) -> Result<String> {
+        let capsule =
+            self.run_pipeline_capsule_with_context(task, context, budget, language, file_hint)?;
+        let mut out = format_capsule(&capsule);
+        let has_swift = capsule
+            .pivots
+            .iter()
+            .any(|p| p.file_path.ends_with(".swift"))
+            || capsule
+                .skeletons
+                .iter()
+                .any(|s| s.file_path.ends_with(".swift"));
+        if has_swift {
+            out.push_str(&swift_enrichment_hint(detect_xcode_mcp()));
+        }
+        Ok(out)
+    }
+
+    /// Same as `run_pipeline_with_context` but returns the structured `Capsule`
+    /// instead of a markdown-formatted string. Used by tooling that needs to
+    /// inspect pivots/skeletons programmatically (e.g. `codesurgeon context
+    /// --json`). Side effects — auto-observation and query logging — are
+    /// identical to the formatted variant; the only thing the formatted path
+    /// adds on top is the markdown rendering and the Swift enrichment hint.
+    pub fn run_pipeline_capsule_with_context(
+        &self,
+        task: &str,
+        context: Option<&str>,
+        budget: Option<u32>,
+        language: Option<&str>,
+        file_hint: Option<&str>,
+    ) -> Result<Capsule> {
         let t0 = Instant::now();
         let budget = budget.unwrap_or(self.config.default_token_budget);
         let intent = SearchIntent::detect(task);
@@ -1346,22 +1377,6 @@ impl CoreEngine {
             task, budget, &intent, language, file_hint, None, None, context,
         )?;
         let latency_ms = t0.elapsed().as_millis() as u64;
-        let mut out = format_capsule(&capsule);
-
-        // Append Swift enrichment hint when Swift symbols appear in results.
-        // Points agents toward Xcode MCP if available, or documents the fallback
-        // so they don't assume the tree-sitter results are complete.
-        let has_swift = capsule
-            .pivots
-            .iter()
-            .any(|p| p.file_path.ends_with(".swift"))
-            || capsule
-                .skeletons
-                .iter()
-                .any(|s| s.file_path.ends_with(".swift"));
-        if has_swift {
-            out.push_str(&swift_enrichment_hint(detect_xcode_mcp()));
-        }
 
         // Auto-capture this tool call as an observation for cross-session memory.
         // Gated on `config.auto_observations` (default false). See the field doc
@@ -1422,7 +1437,7 @@ impl CoreEngine {
             tracing::warn!("query log failed: {}", e);
         }
 
-        Ok(out)
+        Ok(capsule)
     }
 
     /// Get context capsule for a query.

--- a/crates/cs-core/src/lib.rs
+++ b/crates/cs-core/src/lib.rs
@@ -27,3 +27,20 @@ pub use capsule::Capsule;
 pub use engine::{CoreEngine, EngineConfig, IndexStats, SessionContext};
 pub use memory::Observation;
 pub use symbol::{Edge, EdgeKind, Symbol, SymbolKind};
+
+// ── Build identification ─────────────────────────────────────────────────────
+//
+// `GIT_SHA` and `BUILD_TIME` are baked in by `build.rs` so both binaries
+// can report which build is running. `VERSION` is the formatted string
+// surfaced by `codesurgeon --version` and `codesurgeon-mcp --version`.
+
+pub const GIT_SHA: &str = env!("CS_GIT_SHA");
+pub const BUILD_TIME: &str = env!("CS_BUILD_TIME");
+pub const VERSION: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (sha ",
+    env!("CS_GIT_SHA"),
+    ", built ",
+    env!("CS_BUILD_TIME"),
+    ")"
+);

--- a/crates/cs-core/src/ranking.rs
+++ b/crates/cs-core/src/ranking.rs
@@ -39,6 +39,13 @@ pub(crate) const ANCHOR_FUZZY_PROBE: usize = 20;
 /// most-specific anchor hit in that file). Remaining pivot slots are filled
 /// from the BM25/ANN/graph RRF fusion. See docs/explicit-symbol-anchors.md.
 pub(crate) const ANCHOR_FILE_BUDGET: usize = 5;
+/// Per-frame leaf-name probe depth for traceback resolution. Caps how many
+/// candidate symbols we fetch from the `leaf_name` index for a given frame's
+/// function name before applying the file-path suffix filter. A typical leaf
+/// has only a handful of definitions across a workspace; common collision
+/// names (`__init__`, `run`) can have many, but only ones in the frame's
+/// file matter — the file-path filter is the precision lever.
+pub(crate) const TRACEBACK_LEAF_PROBE: usize = 50;
 
 // ── Reverse-edge expansion (issue #67) ───────────────────────────────────────
 //

--- a/crates/cs-core/src/ranking.rs
+++ b/crates/cs-core/src/ranking.rs
@@ -93,6 +93,12 @@ pub(crate) const RRF_K: f32 = 60.0;
 /// Safe because anchor extraction is precision-first: most noise is filtered
 /// out by the stop-word list and the exact-match gate in `anchor_candidates`.
 pub(crate) const ANCHOR_RRF_K: f32 = 15.0;
+/// RRF k for symbols resolved from Python traceback frames. Even more
+/// aggressive than `ANCHOR_RRF_K` because tracebacks carry **both** the
+/// file path and the function name — the resolution is precision-first
+/// by construction, and a frame in the traceback IS a member of the
+/// call chain that produced the bug.
+pub(crate) const TRACEBACK_RRF_K: f32 = 8.0;
 /// Structural injection: score multiplier for injected hub types.
 pub(crate) const STRUCTURAL_INJECTION_SCORE: f32 = 5.0;
 /// Centrality boost multiplier applied to BM25 score.

--- a/crates/cs-core/tests/engine.rs
+++ b/crates/cs-core/tests/engine.rs
@@ -2426,3 +2426,65 @@ RuntimeError: boom
          check: it proves the traceback case above used the new traceback path, not the prose path."
     );
 }
+
+/// Engine-level test for `traceback_candidates`: a traceback frame whose
+/// function name is a class method (`Class.method`) must resolve via
+/// leaf-name lookup, and the suffix-based file-path match must pin down
+/// the *specific* symbol — not the same-named function in another file.
+///
+/// Setup: two files each define a `flush` symbol — one is a top-level
+/// function, the other is `Buffer.flush`. The traceback names the class-method
+/// file, so only that symbol should surface as a traceback pivot.
+#[test]
+fn traceback_resolves_class_method_via_leaf_and_file_path() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("io")).unwrap();
+    std::fs::write(
+        dir.path().join("io/buffer.py"),
+        "class Buffer:\n    def flush(self):\n        return 1\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("io/sink.py"),
+        "def flush():\n    return 2\n",
+    )
+    .unwrap();
+    // Decoys so BM25 / ANN have noise to compete with.
+    for i in 0..6 {
+        std::fs::write(
+            dir.path().join(format!("decoy_{i}.py")),
+            format!("def decoy_func_{i}():\n    return {i}\n"),
+        )
+        .unwrap();
+    }
+    let engine = test_engine(&dir);
+    engine.index_workspace().expect("index");
+
+    let task = "diagnose the reported crash";
+    // Traceback frame names `Buffer.flush` (dotted) in `io/buffer.py`.
+    // The frame's file path is workspace-relative; the resolver's
+    // suffix match must accept it against the indexed `file_path`.
+    let tb = "\
+Traceback (most recent call last):
+  File \"app/main.py\", line 4, in <module>
+    b.flush()
+  File \"io/buffer.py\", line 3, in flush
+    raise RuntimeError(\"boom\")
+RuntimeError: boom
+";
+
+    let capsule = engine
+        .run_pipeline_capsule_with_context(task, Some(tb), Some(4000), None, None)
+        .expect("pipeline");
+
+    let pivot_files: Vec<&str> = capsule
+        .pivots
+        .iter()
+        .map(|p| p.file_path.as_str())
+        .collect();
+    assert!(
+        pivot_files.iter().any(|f| f.ends_with("io/buffer.py")),
+        "traceback frame `File \"io/buffer.py\", in flush` must surface the class method \
+         `Buffer::flush` via leaf-name + suffix-path match. Pivots saw: {pivot_files:?}"
+    );
+}

--- a/crates/cs-mcp/src/main.rs
+++ b/crates/cs-mcp/src/main.rs
@@ -413,6 +413,39 @@ fn release_pid_lock(pid_path: &Path) {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Minimal CLI: respond to --version / -V / --help / -h before spinning
+    // up the JSON-RPC reader. Everything else is treated as MCP traffic
+    // on stdin. Kept hand-rolled (no clap) because the binary's hot path
+    // is JSON-RPC framing — adding clap to parse one flag would pull in
+    // a build-time dep for no runtime benefit.
+    let args: Vec<String> = std::env::args().collect();
+    for arg in args.iter().skip(1) {
+        match arg.as_str() {
+            "--version" | "-V" => {
+                println!("codesurgeon-mcp {}", cs_core::VERSION);
+                return Ok(());
+            }
+            "--help" | "-h" => {
+                println!(
+                    "codesurgeon-mcp {}\n\
+                     \n\
+                     MCP (Model Context Protocol) server for codesurgeon.\n\
+                     Speaks JSON-RPC 2.0 over stdin/stdout.\n\
+                     \n\
+                     Configuration via environment variables:\n\
+                       CS_WORKSPACE   path to the workspace root (required)\n\
+                       CS_LOG         tracing-subscriber filter (default: warn)\n\
+                     \n\
+                     Add to Claude Code with `claude mcp add` — see the\n\
+                     repository README.",
+                    cs_core::VERSION
+                );
+                return Ok(());
+            }
+            _ => {}
+        }
+    }
+
     // Log to stderr so it doesn't pollute the MCP stdio channel
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -15,6 +15,9 @@ Stage 1: Candidate Retrieval
   ├── BM25 (Tantivy)           top-50 lexical matches
   ├── Graph neighbor expansion top-25 1-hop neighbors of BM25 seeds, by centrality
   ├── Explicit anchors         up to 20 exact symbol-name matches from the query
+  ├── Traceback frames         (file_path, function_name) frames extracted from a
+  │                            Python traceback in `context`; resolved via
+  │                            leaf-name + suffix-path match  [PR #97]
   ├── Reverse-edge expansion   up to 20 callers/raisers walked backward (≤3 hops)
   │                            from exception-class anchors  [issue #67]
   └── Semantic (flat scan)     top-25 semantic nearest neighbors  [embeddings build only]
@@ -498,8 +501,10 @@ identifies the coordinator. Requires `>= 2` owned seed types to avoid false posi
 | Anchor rows per distinct name | 5 | `ranking.rs:ANCHOR_ROWS_PER_NAME` |
 | Anchor fuzzy-fallback probe depth | 20 | `ranking.rs:ANCHOR_FUZZY_PROBE` |
 | Anchor fuzzy-fallback cutoff | 3 | `ranking.rs:ANCHOR_FUZZY_CUTOFF` |
+| Traceback per-frame leaf-name probe | 50 | `ranking.rs:TRACEBACK_LEAF_PROBE` |
 | RRF k (BM25 / graph / ANN) | 60 | `ranking.rs:RRF_K` |
 | RRF k (explicit anchors) | 15 | `ranking.rs:ANCHOR_RRF_K` |
+| RRF k (Python traceback frames) | 8 | `ranking.rs:TRACEBACK_RRF_K` |
 | RRF k (reverse expansion) | 30 | `ranking.rs:REVERSE_EXPAND_RRF_K` |
 | Reverse-expansion max depth | 3 | `ranking.rs:REVERSE_EXPAND_MAX_DEPTH` |
 | Reverse-expansion fan-out per hop | 5 | `ranking.rs:REVERSE_EXPAND_FAN_OUT` |


### PR DESCRIPTION
Four small, independent commits extracted from the larger experimental walker work in #93. None of these touch the strategy/direction env-var gates or any walker code — they're all useful regardless of which retrieval strategy ships as default.

## Why this PR

The work in #93 has two cleanly separable groups:

1. **Walker / strategy / direction work** — research line, currently `none` is the panel-recommended default per [cs-benchmark results](https://github.com/subsriram/codesurgeon/issues/96#issuecomment-4347419261). Stays on the experimental branch until empirical evidence shows it moves recall.

2. **Universally-useful infrastructure** — version stamping, JSON CLI surface, anchors debug subcommand, stderr logging, traceback shortcut, and the foundational `leaf_name` lookup that makes anchor + traceback paths actually find class methods. **This PR.**

## Commits

### 1. `build: stamp git SHA + build time into --version on both binaries`

Both binaries previously reported `1.0.0` regardless of build. `codesurgeon-mcp` had no `--version` at all (no CLI parsing, straight to JSON-RPC).

```
$ codesurgeon --version
codesurgeon 1.0.0 (sha c7008a05e6ee, built 2026-04-30T01:41:54Z)
$ codesurgeon-mcp --version
codesurgeon-mcp 1.0.0 (sha c7008a05e6ee, built 2026-04-30T01:41:54Z)
```

`+dirty` marker when working tree has uncommitted changes — important for build identification in benchmark contexts.

### 2. `cli: --json on context/impact + anchors debug subcommand + stderr logging`

- `codesurgeon context … --json` emits the structured `Capsule`. Refactored `run_pipeline_with_context` to delegate to a new `run_pipeline_capsule_with_context` that returns `Capsule`, with the formatted variant wrapping it in markdown.
- `codesurgeon impact … --json` emits the structured `ImpactResult`.
- `codesurgeon anchors <query> [--context <ctx>] [--json]` runs `anchors::extract` directly — useful for debugging "why didn't the fix-site land in pivots?" by checking whether anchor extraction even found the relevant identifier. `Anchors` gains `Serialize`/`Deserialize`.
- cs-cli `tracing_subscriber` writes to stderr (was stdout, polluting `--json` output). Mirrors `codesurgeon-mcp`.

### 3. `engine: traceback shortcut for Python frames`

When `--context` contains a Python traceback, every frame's `(file_path, function_name)` resolves to a high-confidence pivot candidate without going through BM25/embeddings/RRF agreement. The traceback IS the call chain.

- `Anchors::traceback_frames: Vec<TracebackFrame>` populated by the existing `traceback_frame_re` regex.
- `CoreEngine::traceback_candidates(query)` resolves frames via suffix-matched file path + function name.
- `TRACEBACK_RRF_K = 8.0` — more aggressive than `ANCHOR_RRF_K = 15.0`.
- Empty when no traceback present in query/context — zero cost on non-traceback queries.

### 4. `db: leaf_name column so anchor + traceback lookups catch class methods`

**Foundational fix without which commits 2 and 3 are broken for class methods.** The indexer stores class methods with `name = "Class::method"` (existing convention); the `name`-keyed lookups used by `anchor_candidates` and `traceback_candidates` would systematically miss them.

- New `leaf_name TEXT` column + index. Schema migration is idempotent; one-shot Rust backfill loop populates `NULL` rows on first open. **No re-index required** — existing `.codesurgeon/index.db` workspaces auto-migrate.
- `upsert_symbol` writes `leaf_name = name.rsplit("::").next()` for new inserts.
- New `symbols_by_leaf_name` lookup.
- `anchor_candidates` switches to leaf-name lookup (existing `prefer_module` sort still applies).
- `traceback_candidates` matches on `leaf_of_name(sym.name)` instead of `sym.name`.
- 3 new tests in `db::tests` covering pure helper, lookup, and migration paths.

## What's NOT in this PR

- `CS_EXPAND_STRATEGY` env-var gate + 8 walker variants
- `CS_EXPAND_DIRECTION` env-var gate + 4 direction modes
- Forward + reverse walkers (BFS + best-first / v0–v3b)
- Per-seed RRF list split + depth-aware re-weight
- Seed-as-pivot guarantee (separate "promote anchor seeds into RRF" injection)
- Per-seed depth_dist diagnostics

All on `claude/focused-haibt-ea358c` / PR #93 as ongoing research. When/if a future panel run shows walker-side work moving recall, that lands as a separate follow-up PR.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 160 cs-core tests (was 157 on main, +3 leaf_name)
- [x] Smoke: `codesurgeon --version` / `codesurgeon-mcp --version` show SHA + build time
- [x] Smoke: `codesurgeon context "..." --json` emits valid JSON; stderr is empty (or only contains debug log when `CS_LOG=debug`)
- [x] Smoke: `codesurgeon anchors "..." --json` emits valid JSON
- [x] Smoke: `codesurgeon impact "..." --json` emits valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)