### PR TITLE
ci: upload criterion + token-savings JSON as bench artifact

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -65,6 +65,23 @@ jobs:
       - name: Run token savings example (20 queries, advisory)
         run: cargo run --release --example token_savings -p cs-core
 
+      # Upload the raw criterion estimates + token-savings JSON so a baseline
+      # refresh can pull exact median/mean numbers without scraping logs.
+      # Regeneration recipe: trigger this workflow on `main`, download the
+      # `bench-results` artifact, feed the estimates.json files into the
+      # `cs-benchmark/benches/baseline.json` schema (`{median_ns, mean_ns}` per
+      # benchmark name).
+      - name: Upload bench results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bench-results
+          path: |
+            target/criterion/**/new/estimates.json
+            target/token_savings.json
+          if-no-files-found: warn
+          retention-days: 30
+
       - name: Render summary
         id: summary
         if: hashFiles('cs-benchmark/scripts/bench_summary.py') != ''


### PR DESCRIPTION
## Summary

- Adds an `actions/upload-artifact@v7` step to `.github/workflows/bench.yml` that uploads `target/criterion/**/new/estimates.json` and `target/token_savings.json` as a `bench-results` artifact (30-day retention).
- Lets baseline refreshes pull exact median/mean numbers directly from criterion's JSON output instead of scraping the run log.
- `if: always()` so artifacts survive even when a later step (summary render, PR comment) fails — useful when cs-benchmark isn't accessible.

## Test plan

- [x] Workflow YAML lints (no syntax errors)
- [ ] Bench job uploads the `bench-results` artifact on this PR
- [ ] Artifact contains `target/criterion/<bench>/new/estimates.json` files with `median.point_estimate` / `mean.point_estimate` fields
- [ ] No regression in existing summary / PR-comment behavior