### PR TITLE
Revert #69 v2 — semantic similarity in reverse-expand

### DIFF
--- a/crates/cs-core/src/engine.rs
+++ b/crates/cs-core/src/engine.rs
@@ -2638,33 +2638,6 @@ impl CoreEngine {
         // so generic anchors like `parse_latex` or `exp` don't trigger a
         // blowup. Walk is depth- and fan-out-bounded — see ranking.rs
         // REVERSE_EXPAND_* constants.
-        //
-        // Issue #69 v2: when embeddings are available, per-caller scoring
-        // inside the BFS blends the existing query-term-overlap signal with
-        // cosine similarity between the query embedding and each caller's
-        // body embedding. This recovers fix sites like sympy-21379's
-        // `Mod.eval` whose body is topically aligned with the problem
-        // statement but has no lexical overlap with the query terms.
-        #[cfg(feature = "embeddings")]
-        let (re_query_vec, re_emb_guard) = {
-            self.ensure_embedding_cache();
-            let qv = self
-                .embedder
-                .get()
-                .and_then(|emb| match emb.embed_one(&anchor_source) {
-                    Ok(v) => Some(v),
-                    Err(e) => {
-                        tracing::warn!("reverse-expand query embed failed: {}", e);
-                        None
-                    }
-                });
-            let guard = qv.as_ref().map(|_| self.embedding_cache.read());
-            (qv, guard)
-        };
-        #[cfg(feature = "embeddings")]
-        let re_emb_lookup: Option<std::collections::HashMap<u64, &[f32]>> =
-            re_emb_guard.as_ref().map(|g| g.iter().collect());
-
         let reverse_results: Vec<(u64, f32)> = if self.config.reverse_expand_anchors {
             let graph = self.graph.read();
             let seed_ids: Vec<u64> = anchor_results
@@ -2687,27 +2660,6 @@ impl CoreEngine {
                 Vec::new()
             } else {
                 let terms = query_terms_for_reverse_expand(&anchor_source);
-
-                #[cfg(feature = "embeddings")]
-                let semantic_closure = |id: u64| -> Option<f32> {
-                    let qv = re_query_vec.as_ref()?;
-                    let v = re_emb_lookup.as_ref()?.get(&id)?;
-                    Some(cosine_similarity(qv, v).clamp(0.0, 1.0))
-                };
-                #[cfg(feature = "embeddings")]
-                let semantic_ref: Option<&dyn Fn(u64) -> Option<f32>> = if re_query_vec.is_some()
-                    && re_emb_lookup
-                        .as_ref()
-                        .map(|m| !m.is_empty())
-                        .unwrap_or(false)
-                {
-                    Some(&semantic_closure)
-                } else {
-                    None
-                };
-                #[cfg(not(feature = "embeddings"))]
-                let semantic_ref: Option<&dyn Fn(u64) -> Option<f32>> = None;
-
                 let out = reverse_expand_from_anchors(
                     &graph,
                     &seed_ids,
@@ -2715,15 +2667,13 @@ impl CoreEngine {
                     REVERSE_EXPAND_MAX_DEPTH,
                     REVERSE_EXPAND_FAN_OUT,
                     REVERSE_EXPAND_CANDIDATES,
-                    semantic_ref,
                 );
                 tracing::debug!(
-                    "reverse-expand: {} seeds → {} candidates (depth={}, fan_out={}, semantic={})",
+                    "reverse-expand: {} seeds → {} candidates (depth={}, fan_out={})",
                     seed_ids.len(),
                     out.len(),
                     REVERSE_EXPAND_MAX_DEPTH,
-                    REVERSE_EXPAND_FAN_OUT,
-                    semantic_ref.is_some()
+                    REVERSE_EXPAND_FAN_OUT
                 );
                 out
             }

--- a/crates/cs-core/src/ranking.rs
+++ b/crates/cs-core/src/ranking.rs
@@ -76,19 +76,6 @@ pub(crate) const REVERSE_EXPAND_RRF_K: f32 = 30.0;
 /// dozens-to-low-hundreds of raisers; this caps the seed set but the per-hop
 /// `REVERSE_EXPAND_FAN_OUT` still bounds each walk.
 pub(crate) const REVERSE_EXPAND_SEED_MAX_CALLERS: usize = 500;
-/// Weight applied to body-text semantic similarity when ranking per-hop
-/// callers inside the reverse-expand walk (issue #69 v2). Multiplies the
-/// `[0, 1]` cosine similarity between the query embedding and each caller's
-/// body embedding. Calibrated so that:
-/// - one lexical term match (`+1.0`) still outweighs a moderately related
-///   caller (`sim ≈ 0.5` → `+1.0` weighted contribution);
-/// - amongst overlap=0 candidates (the common sympy-21379 failure mode
-///   where the fix site has no lexical overlap with the query), semantic
-///   similarity reorders by topical relevance rather than centrality alone.
-///
-/// Only applied when the `embeddings` feature is active AND a per-symbol
-/// embedding lookup is provided to `reverse_expand_from_anchors`.
-pub(crate) const REVERSE_EXPAND_SEMANTIC_WEIGHT: f32 = 2.0;
 
 // ── Fusion & scoring weights ──────────────────────────────────────────────────
 
@@ -212,22 +199,12 @@ pub(crate) fn is_trivial_exception_pivot(sym: &Symbol) -> bool {
 /// BFS reverse walk from `seed_ids` through incoming edges (`dependents`).
 ///
 /// Returns `(id, score)` pairs where earlier hops score higher (`1 / (depth + 1)`).
-/// Within a hop, callers are ranked by query-term overlap in their name/fqn
-/// plus optional body-text semantic similarity, lightly penalized by
-/// centrality so utility hubs don't crowd out the intended fix sites.
-/// Per-hop expansion is capped at `fan_out`.
+/// Within a hop, callers are ranked by query-term overlap in their name/fqn,
+/// lightly penalized by centrality so utility hubs don't crowd out the
+/// intended fix sites. Per-hop expansion is capped at `fan_out`.
 ///
 /// `query_terms` is the already-tokenised, lowercased list of task+context
-/// terms. An empty list still walks the graph, it just selects by centrality
-/// (and semantic similarity, if provided).
-///
-/// `semantic_scorer`, when `Some`, is called once per candidate and should
-/// return the cosine similarity between the query embedding and that
-/// symbol's body embedding in `[0, 1]`. `None` (or a closure returning
-/// `None` for a given id) falls back to pure term-overlap + centrality —
-/// this is the behaviour on no-embeddings builds and on symbols with no
-/// indexed body (e.g. synthetic `Import` entries, already filtered). The
-/// weight is `REVERSE_EXPAND_SEMANTIC_WEIGHT`. See issue #69 v2.
+/// terms. An empty list still walks the graph, it just selects by centrality.
 ///
 /// The return order is BFS order (depth-ascending), preserved for RRF.
 pub(crate) fn reverse_expand_from_anchors(
@@ -237,7 +214,6 @@ pub(crate) fn reverse_expand_from_anchors(
     max_depth: u32,
     fan_out: usize,
     max_total: usize,
-    semantic_scorer: Option<&dyn Fn(u64) -> Option<f32>>,
 ) -> Vec<(u64, f32)> {
     use std::collections::VecDeque;
 
@@ -258,18 +234,9 @@ pub(crate) fn reverse_expand_from_anchors(
             continue;
         }
 
-        // Score each caller by:
-        //   + `overlap` — count of query-term matches in name / fqn
-        //   + `SEMANTIC_WEIGHT * sim` — cosine of body embedding vs query embedding
-        //   − `0.1 * centrality` — small penalty so leaf callers beat utility hubs
-        //     when everything else ties.
-        //
-        // The semantic term closes the gap that motivated #69 v2: for
-        // symptom-anchored queries like sympy-21379, the fix site's *body*
-        // is topically aligned with the problem statement even though its
-        // *name* has no lexical overlap with the query. Term overlap alone
-        // kept such sites out of the top-`fan_out` beam; body-text similarity
-        // surfaces them.
+        // Score each caller: +1 per query-term hit in name/fqn, minus a small
+        // centrality penalty so top-K favours specific leaf callers over
+        // generic utility hubs when term overlap ties.
         //
         // Filter out `SymbolKind::Import` entries (retained after the #69
         // revert — the problem existed at #67 too, just less visible). Import
@@ -292,14 +259,7 @@ pub(crate) fn reverse_expand_from_anchors(
                     })
                     .count() as f32;
                 let centrality = graph.centrality_score(s.id);
-                let semantic = semantic_scorer
-                    .and_then(|f| f(s.id))
-                    .unwrap_or(0.0)
-                    .clamp(0.0, 1.0);
-                (
-                    s.id,
-                    overlap + REVERSE_EXPAND_SEMANTIC_WEIGHT * semantic - centrality * 0.1,
-                )
+                (s.id, overlap - centrality * 0.1)
             })
             .collect();
         scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
@@ -550,167 +510,4 @@ pub(crate) fn resolve_adjacents<'a>(
             *count <= 2 // max 2 symbols per file in adjacents
         })
         .collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::graph::CodeGraph;
-    use crate::language::Language;
-    use crate::symbol::{EdgeKind, Symbol, SymbolKind};
-
-    fn mk(file: &str, name: &str, kind: SymbolKind) -> Symbol {
-        Symbol::new(
-            file,
-            name,
-            kind,
-            1,
-            1,
-            String::new(),
-            None,
-            String::new(),
-            Language::Python,
-        )
-    }
-
-    /// Build a tiny graph: one seed (exception class) and `n` direct callers
-    /// whose names have no lexical overlap with any reasonable query. Returns
-    /// `(graph, seed_id, caller_ids)`.
-    fn graph_with_anonymous_callers(n: usize) -> (CodeGraph, u64, Vec<u64>) {
-        let mut g = CodeGraph::new();
-        let seed = mk("err.py", "MyError", SymbolKind::Class);
-        let seed_id = seed.id;
-        g.add_symbol(seed);
-        let mut caller_ids = Vec::new();
-        for i in 0..n {
-            let c = mk(
-                &format!("c_{i}.py"),
-                &format!("anon_{i}"),
-                SymbolKind::Function,
-            );
-            caller_ids.push(c.id);
-            g.add_symbol(c);
-        }
-        for &cid in &caller_ids {
-            g.add_edge(cid, seed_id, EdgeKind::Calls);
-        }
-        g.warm_caches();
-        (g, seed_id, caller_ids)
-    }
-
-    /// Issue #69 v2: when every direct caller of a seed has zero lexical
-    /// overlap with the query, a semantic scorer that singles out one caller
-    /// must steer the BFS to that caller at `fan_out=1`. This is the
-    /// sympy-21379 failure mode reduced to a unit fixture.
-    #[test]
-    fn semantic_scorer_promotes_aligned_caller_under_zero_overlap() {
-        let (g, seed_id, caller_ids) = graph_with_anonymous_callers(6);
-        let terms: Vec<String> = vec!["substitution".into(), "piecewise".into()];
-        let aligned = caller_ids[3];
-        let scorer = |id: u64| -> Option<f32> {
-            if id == aligned {
-                Some(0.9)
-            } else {
-                Some(0.3)
-            }
-        };
-        let out = reverse_expand_from_anchors(&g, &[seed_id], &terms, 3, 1, 1, Some(&scorer));
-        assert_eq!(out.len(), 1);
-        assert_eq!(
-            out[0].0, aligned,
-            "semantic scorer should promote aligned caller; got {:?}",
-            out
-        );
-    }
-
-    /// Different semantic target, different winner — proves the scorer's
-    /// *output* drives selection, not a fixed id/ordering bias.
-    #[test]
-    fn semantic_scorer_winner_follows_scorer_output() {
-        let (g, seed_id, caller_ids) = graph_with_anonymous_callers(6);
-        let terms: Vec<String> = vec!["substitution".into()];
-        let target = caller_ids[5];
-        let scorer = |id: u64| -> Option<f32> {
-            if id == target {
-                Some(0.95)
-            } else {
-                Some(0.1)
-            }
-        };
-        let out = reverse_expand_from_anchors(&g, &[seed_id], &terms, 3, 1, 1, Some(&scorer));
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].0, target);
-    }
-
-    /// Strong lexical overlap (multiple term matches in name) must still win
-    /// against a high semantic score — the semantic term is a tiebreaker and
-    /// a soft signal for zero-overlap candidates, not a replacement for
-    /// explicit lexical hits. With `SEMANTIC_WEIGHT = 2.0`, two term matches
-    /// (`+2.0`) outweigh one perfect semantic hit (`2.0 * 0.9 = 1.8`).
-    #[test]
-    fn lexical_overlap_still_dominates_when_strong() {
-        let mut g = CodeGraph::new();
-        let seed = mk("err.py", "MyError", SymbolKind::Class);
-        let seed_id = seed.id;
-        g.add_symbol(seed);
-
-        let lexical = mk(
-            "a.py",
-            "substitution_piecewise_handler",
-            SymbolKind::Function,
-        );
-        let lexical_id = lexical.id;
-        g.add_symbol(lexical);
-
-        let semantic = mk("b.py", "anon_helper", SymbolKind::Function);
-        let semantic_id = semantic.id;
-        g.add_symbol(semantic);
-
-        g.add_edge(lexical_id, seed_id, EdgeKind::Calls);
-        g.add_edge(semantic_id, seed_id, EdgeKind::Calls);
-        g.warm_caches();
-
-        let terms: Vec<String> = vec!["substitution".into(), "piecewise".into()];
-        let scorer = |id: u64| -> Option<f32> {
-            if id == semantic_id {
-                Some(0.9)
-            } else {
-                None
-            }
-        };
-
-        let out = reverse_expand_from_anchors(&g, &[seed_id], &terms, 3, 1, 1, Some(&scorer));
-        assert_eq!(out.len(), 1);
-        assert_eq!(
-            out[0].0, lexical_id,
-            "two term matches (+2.0) should outweigh one semantic hit (+1.8)"
-        );
-    }
-
-    /// No semantic scorer → behaviour is identical to the pre-v2 pure term-
-    /// overlap walk. A caller with strictly more lexical overlap must be
-    /// picked regardless of the other caller's graph position.
-    #[test]
-    fn no_scorer_falls_back_to_pure_term_overlap() {
-        let mut g = CodeGraph::new();
-        let seed = mk("err.py", "MyError", SymbolKind::Class);
-        let seed_id = seed.id;
-        g.add_symbol(seed);
-
-        let winner = mk("a.py", "substitution_handler", SymbolKind::Function);
-        let winner_id = winner.id;
-        g.add_symbol(winner);
-        let loser = mk("b.py", "anon_helper", SymbolKind::Function);
-        let loser_id = loser.id;
-        g.add_symbol(loser);
-
-        g.add_edge(winner_id, seed_id, EdgeKind::Calls);
-        g.add_edge(loser_id, seed_id, EdgeKind::Calls);
-        g.warm_caches();
-
-        let terms: Vec<String> = vec!["substitution".into()];
-        let out = reverse_expand_from_anchors(&g, &[seed_id], &terms, 3, 1, 1, None);
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].0, winner_id);
-    }
 }

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -162,16 +162,9 @@ through summarization. See `docs/explicit-symbol-anchors.md` §v1.7.
 - For each seed, BFS walks **incoming edges** (`CodeGraph::dependents` —
   callers, importers, raisers) up to `REVERSE_EXPAND_MAX_DEPTH = 3` hops.
 - Per-hop expansion is capped at `REVERSE_EXPAND_FAN_OUT = 5`. Within a hop,
-  callers are ranked by a blend of **query-term overlap** in name/fqn,
-  **body-text semantic similarity** (embeddings build only — issue #69 v2),
-  and a small centrality penalty so utility hubs don't crowd out specific
-  leaf callers. Scoring:
-  `overlap + REVERSE_EXPAND_SEMANTIC_WEIGHT * cos(query, caller_body) − 0.1 * centrality`.
-  `REVERSE_EXPAND_SEMANTIC_WEIGHT = 2.0` is calibrated so one lexical term
-  match (`+1.0`) still outweighs a moderately related semantic hit
-  (`sim ≈ 0.5` → `+1.0` contribution); the semantic term's job is to
-  reorder the overlap=0 group by topical relevance instead of leaving it
-  to centrality alone.
+  callers are ranked by **query-term overlap** in name/fqn, lightly
+  penalized by centrality so utility hubs don't crowd out specific leaf
+  callers.
 - Seeds with more than `REVERSE_EXPAND_SEED_MAX_CALLERS = 500` direct
   callers are skipped — their reverse set is too broad to rank usefully
   (e.g. a language-wide base exception class in a huge codebase).
@@ -193,20 +186,6 @@ Per-hop ranking by term overlap picks the callers most relevant to the
 task, which for the sympy-21379 case includes `parallel_poly_from_expr`
 (name contains the query term "poly") and routes the walk through the
 intended chain.
-
-**Why body-text semantic similarity (#69 v2):** the #67 implementation
-ranked per-hop callers by query-term overlap alone. On dense graphs, the
-actual fix site often has *no* lexical overlap with the query terms — in
-sympy-21379 the fix site is `Mod.eval`, whose name and body carry no
-"substitution" / "Piecewise" tokens even though the body is topically
-aligned (polynomial arithmetic, numeric edge cases, gcd). With a
-five-way top-K beam, such sites are systematically dropped. Adding
-`cos(query_embedding, caller_body_embedding)` as a secondary per-hop
-signal reorders the overlap=0 group by topical relevance, which recovers
-the fix site without displacing strong lexical hits (see the weight
-calibration above). Infrastructure reuse: the per-symbol embeddings
-already exist for ANN retrieval (stage 1e); reverse-expand builds a
-`HashMap<u64, &[f32]>` over the mmap'd cache once per `run_pipeline`.
 
 **Reverse-expanded candidates participate in v1.6 file-diversity pinning**
 alongside direct anchors — a walked caller in an otherwise-uncontested
@@ -510,7 +489,6 @@ identifies the coordinator. Requires `>= 2` owned seed types to avoid false posi
 | Reverse-expansion fan-out per hop | 5 | `ranking.rs:REVERSE_EXPAND_FAN_OUT` |
 | Reverse-expansion candidate cap | 20 | `ranking.rs:REVERSE_EXPAND_CANDIDATES` |
 | Reverse-expansion seed max callers | 500 | `ranking.rs:REVERSE_EXPAND_SEED_MAX_CALLERS` |
-| Reverse-expansion semantic weight (#69 v2) | 2.0 | `ranking.rs:REVERSE_EXPAND_SEMANTIC_WEIGHT` |
 | Structural injection cap | `max_pivots * 2` = 16 | `engine.rs:inject_structural_candidates` |
 | Injected candidate score | `family_in_degree * 5.0` | `engine.rs:inject_structural_candidates` |
 | Centrality boost multiplier | 3.0 | `engine.rs:apply_centrality_and_semantics` |


### PR DESCRIPTION
## Summary

Reverts [8684552](https://github.com/subsriram/codesurgeon/commit/8684552) ("ranking: body-text semantic similarity in reverse-expand (#69 v2)").

The change extended `reverse_expand_from_anchors` with a per-caller cosine-similarity scorer and wired in a closure that embedded the query against each caller's body embedding. Targeted one specific failure: sympy-21379's `Mod.eval` (symptom-anchored bug report with no lexical overlap to the fix site).

## Why revert

1. **The fix didn't land.** Issue [#95](https://github.com/subsriram/codesurgeon/issues/95) documents the empirical result: across **8 reverse-expand variants × 5 SWE-bench Verified tasks**, `0/40` rows had `fix_site_in_pivots: true`. sympy-21379 still misses with the semantic scorer in place — so the change pays cost without delivering its win.

2. **The cost is real and unconditional.** In `build_context_capsule`, the closure setup runs `embed_one(&anchor_source)` on **every** pipeline invocation when the embeddings feature is on, before we know whether reverse-expand will fire. Most queries (no exception-class anchor) never use the result.

3. **The replacement has landed.** PR #97 introduced the **traceback shortcut** (Layer 1 of #95's proposal) — the explicit move toward bidirectional / forward-walk strategies. The reverse-expand-only path is being superseded; piling more cost into it doesn't make sense.

## What this changes

- `engine.rs`: drops the embedding cache + closure plumbing in `build_context_capsule`, simplifies `reverse_expand_from_anchors` call signature back to its pre-#69-v2 form.
- `ranking.rs`: removes the optional `semantic` parameter and the `REVERSE_EXPAND_SEMANTIC_WEIGHT` constant from `reverse_expand_from_anchors`. Reverse-expand still runs — it just scores callers by the v1 `overlap − 0.1 × centrality` rule.
- `docs/ranking.md`: rolls back the v2 narrative; reverse-expand is back to its #67 description.

275 net lines removed. Reverse-edge expansion itself is preserved — only the body-text semantic scorer is gone.

## Test plan

- [x] `cargo build -p cs-core` (default features) — clean
- [x] `cargo build -p cs-core --features metal` — clean
- [x] `cargo test --workspace` — all 359 tests pass
- [x] `cargo test -p cs-core --features metal` — all tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo clippy -p cs-core --features metal -- -D warnings` — clean
- [ ] CI (rustfmt + clippy + test + bench)
- [ ] Bench against fresh baseline (cs-benchmark@2026-04-30) — expect a perf improvement on every `run_pipeline` query when embeddings feature is active, since `embed_one` no longer runs unconditionally
- [ ] Future PRs implementing #95's bidirectional / forward-walk approach can re-introduce semantic scoring in the right place

## Risks

- Loses the *specific* sympy-21379 mitigation. But the bench evidence shows it wasn't actually mitigating that task in pivots — `0/40` is unambiguous. If a future change does fix sympy-21379, it'll be via the bidirectional / shape-classifier work proposed in #95, not via this scorer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)