### PR TITLE
ranking: defer reverse-expand query embed until seeds are non-empty

### DIFF
--- a/crates/cs-core/src/engine.rs
+++ b/crates/cs-core/src/engine.rs
@@ -2644,27 +2644,10 @@ impl CoreEngine {
         // cosine similarity between the query embedding and each caller's
         // body embedding. This recovers fix sites like sympy-21379's
         // `Mod.eval` whose body is topically aligned with the problem
-        // statement but has no lexical overlap with the query terms.
-        #[cfg(feature = "embeddings")]
-        let (re_query_vec, re_emb_guard) = {
-            self.ensure_embedding_cache();
-            let qv = self
-                .embedder
-                .get()
-                .and_then(|emb| match emb.embed_one(&anchor_source) {
-                    Ok(v) => Some(v),
-                    Err(e) => {
-                        tracing::warn!("reverse-expand query embed failed: {}", e);
-                        None
-                    }
-                });
-            let guard = qv.as_ref().map(|_| self.embedding_cache.read());
-            (qv, guard)
-        };
-        #[cfg(feature = "embeddings")]
-        let re_emb_lookup: Option<std::collections::HashMap<u64, &[f32]>> =
-            re_emb_guard.as_ref().map(|g| g.iter().collect());
-
+        // statement but has no lexical overlap with the query terms. The
+        // query embedding + cache load are deferred to the seed-non-empty
+        // branch — paying that cost on every pipeline call (when most
+        // queries have no exception-class anchor) is pure waste.
         let reverse_results: Vec<(u64, f32)> = if self.config.reverse_expand_anchors {
             let graph = self.graph.read();
             let seed_ids: Vec<u64> = anchor_results
@@ -2687,6 +2670,26 @@ impl CoreEngine {
                 Vec::new()
             } else {
                 let terms = query_terms_for_reverse_expand(&anchor_source);
+
+                #[cfg(feature = "embeddings")]
+                let (re_query_vec, re_emb_guard) = {
+                    self.ensure_embedding_cache();
+                    let qv =
+                        self.embedder
+                            .get()
+                            .and_then(|emb| match emb.embed_one(&anchor_source) {
+                                Ok(v) => Some(v),
+                                Err(e) => {
+                                    tracing::warn!("reverse-expand query embed failed: {}", e);
+                                    None
+                                }
+                            });
+                    let guard = qv.as_ref().map(|_| self.embedding_cache.read());
+                    (qv, guard)
+                };
+                #[cfg(feature = "embeddings")]
+                let re_emb_lookup: Option<std::collections::HashMap<u64, &[f32]>> =
+                    re_emb_guard.as_ref().map(|g| g.iter().collect());
 
                 #[cfg(feature = "embeddings")]
                 let semantic_closure = |id: u64| -> Option<f32> {


### PR DESCRIPTION
## Summary

Replaces the wholesale revert in #99 with a narrower, behavior-preserving perf fix.

`build_context_capsule` was running \`embed_one(&anchor_source)\` (+ embedding cache load) on **every pipeline invocation** when the embeddings feature was on, regardless of whether reverse-expand would actually fire. Most queries don't carry an exception-class anchor, so the seed list is empty and the embedding gets discarded — pure waste.

This moves the embedding setup inside the seed-non-empty branch, where the semantic scorer is actually used. No behavior change otherwise: same closure, same \`semantic_ref\` gating, same RRF inputs.

## Why not the wholesale revert (#99)?

PR [#93](https://github.com/subsriram/codesurgeon/pull/93) ([claude/focused-haibt-ea358c](https://github.com/subsriram/codesurgeon/tree/claude/focused-haibt-ea358c)) is the active in-flight branch implementing #95/#96 (bidirectional + traceback). It builds on the semantic-scorer infrastructure with a new \`strategy.use_semantic()\` gate — the scorer is now a tunable knob in the strategy framework, not dead code.

Reverting wholesale would force #93 to re-introduce ~50 lines on rebase. This narrower change preserves the API and only fixes the actual perf bug.

## Test plan

- [x] \`cargo build -p cs-core\` (default features) — clean
- [x] \`cargo build -p cs-core --features metal\` — clean
- [x] \`cargo test --workspace\` — all tests pass
- [x] \`cargo test -p cs-core --features metal\` — 176 + 92 + ... all pass
- [x] \`cargo clippy --workspace -- -D warnings\` — clean
- [x] \`cargo clippy -p cs-core --features metal -- -D warnings\` — clean
- [x] \`cargo fmt --all\` — clean
- [ ] CI (rustfmt + clippy + test + bench)
- [ ] Bench delta: expect a small consistent win on \`run_pipeline/*\` queries with no exception-class anchor (the common case), since one Transformer forward pass per pipeline call is no longer wasted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)